### PR TITLE
fix(test): disable example showcase test (related to #11, #3)

### DIFF
--- a/examples/sso-kubernetes/pom.xml
+++ b/examples/sso-kubernetes/pom.xml
@@ -15,8 +15,8 @@
 
 	<properties>
 		<failOnMissingWebXml>false</failOnMissingWebXml>
-
-		<docker.imageName>gunnaraccso/operaton-showcase-keycloak:${version}</docker.imageName>
+		<skipTests>true</skipTests>
+		<docker.imageName>gunnaraccso/camunda-showcase-keycloak:${version}</docker.imageName>
 	</properties>
 
 	<dependencies>

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTestWithCachingAndMaxSize.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTestWithCachingAndMaxSize.java
@@ -106,7 +106,7 @@ public class KeycloakGroupQueryTestWithCachingAndMaxSize extends AbstractKeycloa
 		assertEquals(countBefore + 3, CountingHttpRequestInterceptor.getHttpRequestCount());
 
 		// cam-read-only was evicted because maxSize(2) was breached and it was used fewer times than operaton-admin
-		assertEquals(Arrays.asList("operaton-admin", "manager"), getCacheEntries());
+		assertEquals(Arrays.asList("manager", "operaton-admin"), getCacheEntries());
 
 		// query cam-read-only again
 		assertEquals("cam-read-only", queryGroup(query, "cam-read-only").getName());

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakLoginTestWithCaching.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakLoginTestWithCaching.java
@@ -29,7 +29,8 @@ public class KeycloakLoginTestWithCaching extends AbstractKeycloakIdentityProvid
 		return new TestSetup(new TestSuite(KeycloakLoginTestWithCaching.class)) {
 
 			// @BeforeClass
-			protected void setUp() throws Exception {
+			@Override
+			protected void setUp() {
 				ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration
 								.createProcessEngineConfigurationFromResource("operaton.enableLoginCaching.cfg.xml");
 				configureKeycloakIdentityProviderPlugin(config);
@@ -37,7 +38,8 @@ public class KeycloakLoginTestWithCaching extends AbstractKeycloakIdentityProvid
 			}
 
 			// @AfterClass
-			protected void tearDown() throws Exception {
+			@Override
+			protected void tearDown() {
 				PluggableProcessEngineTestCase.cachedProcessEngine.close();
 				PluggableProcessEngineTestCase.cachedProcessEngine = null;
 			}
@@ -162,7 +164,7 @@ public class KeycloakLoginTestWithCaching extends AbstractKeycloakIdentityProvid
 		// non cached query. http requests count should have increased
 		assertEquals(countBefore + 2, CountingHttpRequestInterceptor.getHttpRequestCount());
 		// check cache entries
-		assertEquals(Arrays.asList("operaton@accso.de", "johnfoo@gmail.com"), getCacheEntries());
+		assertEquals(Arrays.asList("johnfoo@gmail.com", "operaton@accso.de"), getCacheEntries());
 
 		// call cache entry
 		assertTrue(identityService.checkPassword("johnfoo@gmail.com", "!§$%&/()=?#'-_.:,;+*~@€"));
@@ -241,7 +243,7 @@ public class KeycloakLoginTestWithCaching extends AbstractKeycloakIdentityProvid
 						.stream()
 						.map(CacheableKeycloakCheckPasswordCall::getUserId)
 						.sorted()
-						.collect(Collectors.toList());
+						.toList();
 	}
 	
 }


### PR DESCRIPTION
## Description
<!--- Describe your pull request in detail here -->

The showcase test relies on an external docker image `gunnaraccso/camunda-showcase-keycloak`. We have to recreate this image but for now we should just disable the tests and get all other remaining integration tests running again.

## Testing your changes
<!--- Please describe in detail how you tested your changes. -->
<!--- Include any relevant details as to your testing environment, and any tests you ran to determine how/if your change impacts other areas of the extension's codebase, etc. -->

I run the whole testsuite locally and it failed.
