### PR TITLE
chore: Code cleanup

### DIFF
--- a/examples/sso-kubernetes/pom.xml
+++ b/examples/sso-kubernetes/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<failOnMissingWebXml>false</failOnMissingWebXml>
 		<skipTests>true</skipTests>
-		<docker.imageName>gunnaraccso/camunda-showcase-keycloak:${version}</docker.imageName>
+		<docker.imageName>gunnaraccso/camunda-showcase-keycloak:${project.version}</docker.imageName>
 	</properties>
 
 	<dependencies>

--- a/examples/sso-kubernetes/src/main/java/org/operaton/bpm/extension/keycloak/showcase/rest/KeycloakAuthenticationFilter.java
+++ b/examples/sso-kubernetes/src/main/java/org/operaton/bpm/extension/keycloak/showcase/rest/KeycloakAuthenticationFilter.java
@@ -28,14 +28,14 @@ public class KeycloakAuthenticationFilter implements Filter {
 
 	/** This class' logger. */
 	private static final Logger LOG = LoggerFactory.getLogger(KeycloakAuthenticationFilter.class);
-	
+
 	/** Access to Operaton's IdentityService. */
-	private IdentityService identityService;
+	private final IdentityService identityService;
 	
 	/** Access to the OAuth2 client service. */
 	OAuth2AuthorizedClientService clientService;
 
-	private String userNameAttribute;
+	private final String userNameAttribute;
 	
 	/**
 	 * Creates a new KeycloakAuthenticationFilter.

--- a/examples/sso-kubernetes/src/main/java/org/operaton/bpm/extension/keycloak/showcase/task/LoggerDelegate.java
+++ b/examples/sso-kubernetes/src/main/java/org/operaton/bpm/extension/keycloak/showcase/task/LoggerDelegate.java
@@ -15,10 +15,10 @@ import org.operaton.bpm.engine.delegate.JavaDelegate;
 @Named("logger")
 public class LoggerDelegate implements JavaDelegate {
  
-  private final Logger LOGGER = Logger.getLogger(LoggerDelegate.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(LoggerDelegate.class.getName());
   
   public void execute(DelegateExecution execution) throws Exception {
-    
+
     LOGGER.info("\n\n  ... LoggerDelegate invoked by "
             + "processDefinitionId=" + execution.getProcessDefinitionId()
             + ", activtyId=" + execution.getCurrentActivityId()

--- a/extension-jwt/src/main/java/org/operaton/bpm/extension/keycloak/auth/KeycloakJwtAuthenticationFilter.java
+++ b/extension-jwt/src/main/java/org/operaton/bpm/extension/keycloak/auth/KeycloakJwtAuthenticationFilter.java
@@ -66,7 +66,9 @@ public class KeycloakJwtAuthenticationFilter extends ContainerBasedAuthenticatio
                 List<String> groups = authenticationResult.getGroups();
                 List<String> tenants = authenticationResult.getTenants();
                 UserAuthentication authentication = this.createAuthentication(engine, authenticatedUser, groups, tenants);
-                if (authentication != null) authentications.addOrReplace(authentication);
+				if (authentication != null) {
+					authentications.addOrReplace(authentication);
+				}
             }
 
             Authentications.setCurrent(authentications);

--- a/extension/src/main/java/org/operaton/bpm/extension/keycloak/CacheableKeycloakCheckPasswordCall.java
+++ b/extension/src/main/java/org/operaton/bpm/extension/keycloak/CacheableKeycloakCheckPasswordCall.java
@@ -51,12 +51,15 @@ public class CacheableKeycloakCheckPasswordCall {
 	 */
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		}
+		if (obj == null) {
 			return false;
-		if (getClass() != obj.getClass())
+		}
+		if (getClass() != obj.getClass()) {
 			return false;
+		}
 		CacheableKeycloakCheckPasswordCall other = (CacheableKeycloakCheckPasswordCall) obj;
 		return Objects.equals(hash, other.hash) && Objects.equals(userId, other.userId);
 	}

--- a/extension/src/main/java/org/operaton/bpm/extension/keycloak/CacheableKeycloakGroupQuery.java
+++ b/extension/src/main/java/org/operaton/bpm/extension/keycloak/CacheableKeycloakGroupQuery.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  * Immutable wrapper over KeycloakGroupQuery that can be used as a cache key.
  * Note: keep equals/hashcode in sync with the list of fields
  */
-public class CacheableKeycloakGroupQuery {
+public final class CacheableKeycloakGroupQuery {
 
 	private final String id;
 	private final String[] ids;
@@ -61,8 +61,12 @@ public class CacheableKeycloakGroupQuery {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
 		CacheableKeycloakGroupQuery that = (CacheableKeycloakGroupQuery) o;
 		return Objects.equals(id, that.id) &&
 						Arrays.equals(ids, that.ids) &&

--- a/extension/src/main/java/org/operaton/bpm/extension/keycloak/CacheableKeycloakUserQuery.java
+++ b/extension/src/main/java/org/operaton/bpm/extension/keycloak/CacheableKeycloakUserQuery.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  * Immutable wrapper over KeycloakUserQuery that can be used as a cache key.
  * Note: keep equals/hashcode in sync with the list of fields
  */
-public class CacheableKeycloakUserQuery {
+public final class CacheableKeycloakUserQuery {
 
 	private final String id;
 	private final String[] ids;
@@ -73,8 +73,12 @@ public class CacheableKeycloakUserQuery {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
 		CacheableKeycloakUserQuery that = (CacheableKeycloakUserQuery) o;
 		return Objects.equals(id, that.id) && 
 						Arrays.equals(ids, that.ids) && 

--- a/extension/src/main/java/org/operaton/bpm/extension/keycloak/KeycloakConfiguration.java
+++ b/extension/src/main/java/org/operaton/bpm/extension/keycloak/KeycloakConfiguration.java
@@ -24,18 +24,18 @@ public class KeycloakConfiguration {
 	/**
 	 * Whether to use the email attribute as Operaton user ID. Activate this when not using SSO.
 	 */
-	protected boolean useEmailAsOperatonUserId = false;
+	protected boolean useEmailAsOperatonUserId;
 
 	/**
 	 * Whether to use the username attribute as Operaton user ID. Set keycloak.principal-attribute=preferred_username*
 	 */
-	protected boolean useUsernameAsOperatonUserId = false;
+	protected boolean useUsernameAsOperatonUserId;
 
 	/**
 	 * Whether to use the group's path as Operaton group ID. Makes sense in case you want to have human readable group IDs
 	 * and e.g. use them in Operaton's authorization configuration.
 	 */
-	protected boolean useGroupPathAsOperatonGroupId = false;
+	protected boolean useGroupPathAsOperatonGroupId;
 
 	/**
 	 * Starting with Keycloak version 23.x the group query without any other search parameters does not automatically
@@ -46,7 +46,7 @@ public class KeycloakConfiguration {
 	 * Set this flag to 'true' in case you use subgroups together with Keycloak 23 or higher.
 	 * </p>
 	 */
-	protected boolean enforceSubgroupsInGroupQuery = false;
+	protected boolean enforceSubgroupsInGroupQuery;
 
 	/** The name of the administrator group.
 	 *
@@ -66,7 +66,7 @@ public class KeycloakConfiguration {
 	protected boolean authorizationCheckEnabled = true;
 
 	/** Disables SSL certificate validation. Useful for testing. */
-	protected boolean disableSSLCertificateValidation = false;
+	protected boolean disableSSLCertificateValidation;
 
 	/** The file path to a truststore file. */
 	protected String truststore;
@@ -84,13 +84,13 @@ public class KeycloakConfiguration {
 	protected Integer maxResultSize = 250;
 
 	/** The optional proxy URI. */
-	protected String proxyUri = null;
+	protected String proxyUri;
 
 	/** The optional proxy user. */
-	protected String proxyUser = null;
+	protected String proxyUser;
 
 	/** The optional proxy password. */
-	protected String proxyPassword = null;
+	protected String proxyPassword;
 
 	/** Determines if queries to Keycloak are cached. default: false */
 	private boolean cacheEnabled;
@@ -111,7 +111,7 @@ public class KeycloakConfiguration {
 	 * Not applicable in case of SSO logins, but useful e.g. in case of massive 
 	 * External Tasks clients using HTTP Basic Auth only.
 	 */
-	private boolean loginCacheEnabled = false;
+	private boolean loginCacheEnabled;
 
 	/**
 	 * Maximum size of the login cache. Least used entries are evicted when this limit is reached. 

--- a/extension/src/main/java/org/operaton/bpm/extension/keycloak/KeycloakContext.java
+++ b/extension/src/main/java/org/operaton/bpm/extension/keycloak/KeycloakContext.java
@@ -9,9 +9,9 @@ import org.springframework.http.HttpHeaders;
  */
 public class KeycloakContext {
 
-	private HttpHeaders headers;
-	
-	private long expiresAt;
+	private final HttpHeaders headers;
+
+	private final long expiresAt;
 	
 	String refreshToken;
 	

--- a/extension/src/main/java/org/operaton/bpm/extension/keycloak/KeycloakContextProvider.java
+++ b/extension/src/main/java/org/operaton/bpm/extension/keycloak/KeycloakContextProvider.java
@@ -22,7 +22,7 @@ import com.google.gson.JsonObject;
  */
 public class KeycloakContextProvider {
 
-	private final static KeycloakPluginLogger LOG = KeycloakPluginLogger.INSTANCE;
+	private static final KeycloakPluginLogger LOG = KeycloakPluginLogger.INSTANCE;
 
 	protected KeycloakConfiguration keycloakConfiguration;
 	protected KeycloakRestTemplate restTemplate;
@@ -47,7 +47,7 @@ public class KeycloakContextProvider {
 	private KeycloakContext openAuthorizationContext() {
 		HttpHeaders headers = new HttpHeaders();
 		headers.add(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED + ";charset=" + keycloakConfiguration.getCharset());
-		HttpEntity<String> request = new HttpEntity<String>(
+		HttpEntity<String> request = new HttpEntity<>(
 	    		"client_id=" + keycloakConfiguration.getClientId()
 	    		+ "&client_secret=" + keycloakConfiguration.getClientSecret()
 	    		+ "&grant_type=client_credentials",
@@ -84,7 +84,7 @@ public class KeycloakContextProvider {
 	private KeycloakContext refreshToken() {
 		HttpHeaders headers = new HttpHeaders();
 		headers.add(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED + ";charset=" + keycloakConfiguration.getCharset());
-		HttpEntity<String> request = new HttpEntity<String>(
+		HttpEntity<String> request = new HttpEntity<>(
 	    		"client_id=" + keycloakConfiguration.getClientId()
 	    		+ "&client_secret=" + keycloakConfiguration.getClientSecret()
 	    		+ "&refresh_token=" + context.getRefreshToken()

--- a/extension/src/main/java/org/operaton/bpm/extension/keycloak/KeycloakGroupService.java
+++ b/extension/src/main/java/org/operaton/bpm/extension/keycloak/KeycloakGroupService.java
@@ -206,7 +206,7 @@ public class KeycloakGroupService extends KeycloakServiceBase {
 		Stream<Group> processed = groupList.stream().filter(group -> isValid(query, group, resultLogger));
 		
 		// sort groups according to query criteria
-		if (query.getOrderingProperties().size() > 0) {
+		if (!query.getOrderingProperties().isEmpty()) {
 			processed = processed.sorted(new GroupComparator(query.getOrderingProperties()));
 		}
 
@@ -228,11 +228,21 @@ public class KeycloakGroupService extends KeycloakServiceBase {
 	 */
 	private boolean isValid(KeycloakGroupQuery query, Group group, StringBuilder resultLogger) {
 		// client side check of further query filters
-		if (!matches(query.getId(), group.getId())) return false;
-		if (!matches(query.getIds(), group.getId())) return false;
-		if (!matches(query.getName(), group.getName())) return false;
-		if (!matchesLike(query.getNameLike(), group.getName())) return false;
-		if (!matches(query.getType(), group.getType())) return false;
+		if (!matches(query.getId(), group.getId())) {
+			return false;
+		}
+		if (!matches(query.getIds(), group.getId())) {
+			return false;
+		}
+		if (!matches(query.getName(), group.getName())) {
+			return false;
+		}
+		if (!matchesLike(query.getNameLike(), group.getName())) {
+			return false;
+		}
+		if (!matches(query.getType(), group.getType())) {
+			return false;
+		}
 
 		// authenticated user is always allowed to query his own groups
 		// otherwise READ authentication is required
@@ -286,7 +296,9 @@ public class KeycloakGroupService extends KeycloakServiceBase {
 	 * @throws JsonException in case of errors
 	 */
 	private JsonArray flattenSubGroups(JsonArray groups, JsonArray result) throws JsonException {
-		if (groups == null) return result;
+		if (groups == null) {
+			return result;
+		}
 	    for (int i = 0; i < groups.size(); i++) {
 	    	JsonObject group = getJsonObjectAtIndex(groups, i);
 	    	JsonArray subGroups;
@@ -320,11 +332,11 @@ public class KeycloakGroupService extends KeycloakServiceBase {
 			ResponseEntity<String> response = restTemplate.exchange(
 					keycloakConfiguration.getKeycloakAdminUrl() + groupSearch, HttpMethod.GET, String.class);
 			String result = "[" + response.getBody() + "]";
-			return new ResponseEntity<String>(result, response.getHeaders(), response.getStatusCode());
+			return new ResponseEntity<>(result, response.getHeaders(), response.getStatusCode());
 		} catch (HttpClientErrorException hcee) {
 			if (hcee.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
 				String result = "[]";
-				return new ResponseEntity<String>(result, HttpStatus.OK);
+				return new ResponseEntity<>(result, HttpStatus.OK);
 			}
 			throw hcee;
 		}
@@ -381,9 +393,9 @@ public class KeycloakGroupService extends KeycloakServiceBase {
 	 * Helper for client side group ordering.
 	 */
 	private static class GroupComparator implements Comparator<Group> {
-		private final static int GROUP_ID = 0;
-		private final static int NAME = 1;
-		private final static int TYPE = 2;
+		private static final int GROUP_ID = 0;
+		private static final int NAME = 1;
+		private static final int TYPE = 2;
 
 		private final int[] order;
 		private final boolean[] desc;

--- a/extension/src/main/java/org/operaton/bpm/extension/keycloak/KeycloakIdentityProviderSession.java
+++ b/extension/src/main/java/org/operaton/bpm/extension/keycloak/KeycloakIdentityProviderSession.java
@@ -193,7 +193,7 @@ public class KeycloakIdentityProviderSession implements ReadOnlyIdentityProvider
 	@Override
 	public boolean checkPassword(String userId, String password) {
 		return checkPasswordCache.getOrCompute(new CacheableKeycloakCheckPasswordCall(userId, password), 
-				(c) -> this.doCheckPassword(c.getUserId(), password));
+				c -> this.doCheckPassword(c.getUserId(), password));
 	}
 
 	/**

--- a/extension/src/main/java/org/operaton/bpm/extension/keycloak/KeycloakServiceBase.java
+++ b/extension/src/main/java/org/operaton/bpm/extension/keycloak/KeycloakServiceBase.java
@@ -143,9 +143,13 @@ public abstract class KeycloakServiceBase {
 	 * @return the truncated list
 	 */
 	protected <T> List<T> truncate(List<T> list, int maxSize) {
-		if (list == null) return list;
+		if (list == null) {
+			return list;
+		}
 		int actualSize = list.size();
-		if (actualSize <=  maxSize) return list;
+		if (actualSize <= maxSize) {
+			return list;
+		}
 		return list.subList(0, maxSize);
 	}
 	

--- a/extension/src/main/java/org/operaton/bpm/extension/keycloak/KeycloakUserService.java
+++ b/extension/src/main/java/org/operaton/bpm/extension/keycloak/KeycloakUserService.java
@@ -221,7 +221,7 @@ public class KeycloakUserService extends KeycloakServiceBase {
 		Stream<User> processed = userList.stream().filter(user -> isValid(query, user, resultLogger));
 
 		// sort users according to query criteria
-		if (query.getOrderingProperties().size() > 0) {
+		if (!query.getOrderingProperties().isEmpty()) {
 			processed = processed.sorted(new UserComparator(query.getOrderingProperties()));
 		}
 
@@ -244,14 +244,30 @@ public class KeycloakUserService extends KeycloakServiceBase {
 		// client side check of further query filters
 		// beware: looks like most attributes are treated as 'like' queries on Keycloak
 		//         and must therefore be seen as a sort of pre-filter only
-		if (!matches(query.getId(), user.getId())) return false;
-		if (!matches(query.getIds(), user.getId())) return false;
-		if (!matches(query.getEmail(), user.getEmail())) return false;
-		if (!matchesLike(query.getEmailLike(), user.getEmail())) return false;
-		if (!matches(query.getFirstName(), user.getFirstName())) return false;
-		if (!matchesLike(query.getFirstNameLike(), user.getFirstName())) return false;
-		if (!matches(query.getLastName(), user.getLastName())) return false;
-		if (!matchesLike(query.getLastNameLike(), user.getLastName())) return false;
+		if (!matches(query.getId(), user.getId())) {
+			return false;
+		}
+		if (!matches(query.getIds(), user.getId())) {
+			return false;
+		}
+		if (!matches(query.getEmail(), user.getEmail())) {
+			return false;
+		}
+		if (!matchesLike(query.getEmailLike(), user.getEmail())) {
+			return false;
+		}
+		if (!matches(query.getFirstName(), user.getFirstName())) {
+			return false;
+		}
+		if (!matchesLike(query.getFirstNameLike(), user.getFirstName())) {
+			return false;
+		}
+		if (!matches(query.getLastName(), user.getLastName())) {
+			return false;
+		}
+		if (!matchesLike(query.getLastNameLike(), user.getLastName())) {
+			return false;
+		}
 
 		if(isAuthenticatedUser(user.getId()) || isAuthorized(READ, USER, user.getId())) {
 			if (KeycloakPluginLogger.INSTANCE.isDebugEnabled()) {
@@ -318,14 +334,14 @@ public class KeycloakUserService extends KeycloakServiceBase {
 
 			ResponseEntity<String> response = restTemplate.exchange(
 					keycloakConfiguration.getKeycloakAdminUrl() + userSearch, HttpMethod.GET, String.class);
-			String result = (keycloakConfiguration.isUseEmailAsOperatonUserId() || keycloakConfiguration.isUseUsernameAsOperatonUserId())
+			String result = keycloakConfiguration.isUseEmailAsOperatonUserId() || keycloakConfiguration.isUseUsernameAsOperatonUserId()
 					? response.getBody()
 					: "[" + response.getBody() + "]";
-			return new ResponseEntity<String>(result, response.getHeaders(), response.getStatusCode());
+			return new ResponseEntity<>(result, response.getHeaders(), response.getStatusCode());
 		} catch (HttpClientErrorException hcee) {
 			if (hcee.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
 				String result = "[]";
-				return new ResponseEntity<String>(result, HttpStatus.OK);
+				return new ResponseEntity<>(result, HttpStatus.OK);
 			}
 			throw hcee;
 		}
@@ -359,10 +375,10 @@ public class KeycloakUserService extends KeycloakServiceBase {
 	 * Helper for client side user ordering.
 	 */
 	private static class UserComparator implements Comparator<User> {
-		private final static int USER_ID = 0;
-		private final static int EMAIL = 1;
-		private final static int FIRST_NAME = 2;
-		private final static int LAST_NAME = 3;
+		private static final int USER_ID = 0;
+		private static final int EMAIL = 1;
+		private static final int FIRST_NAME = 2;
+		private static final int LAST_NAME = 3;
 
 		private final int[] order;
 		private final boolean[] desc;

--- a/extension/src/main/java/org/operaton/bpm/extension/keycloak/cache/CacheConfiguration.java
+++ b/extension/src/main/java/org/operaton/bpm/extension/keycloak/cache/CacheConfiguration.java
@@ -7,7 +7,7 @@ import java.time.Duration;
 /**
  * Query/Login Cache Configuration as parsed from KeycloakConfiguration.
  */
-public class CacheConfiguration {
+public final class CacheConfiguration {
 
 	private final boolean enabled;
 	private final int maxSize;

--- a/extension/src/main/java/org/operaton/bpm/extension/keycloak/json/JsonUtil.java
+++ b/extension/src/main/java/org/operaton/bpm/extension/keycloak/json/JsonUtil.java
@@ -107,7 +107,9 @@ public class JsonUtil {
 	 * @throws JsonException in case of errors
 	 */
 	public static JsonObject getJsonObject(JsonObject jsonObject, String memberName) throws JsonException {
-		if (jsonObject == null) return null;
+		if (jsonObject == null) {
+			return null;
+		}
 		try {
 			JsonElement element = jsonObject.get(memberName);
 			return element == null ? null : element.getAsJsonObject();
@@ -124,7 +126,9 @@ public class JsonUtil {
 	 * @throws JsonException in case of errors
 	 */
 	public static JsonArray getJsonArray(JsonObject jsonObject, String memberName) throws JsonException {
-		if (jsonObject == null) return new JsonArray();
+		if (jsonObject == null) {
+			return new JsonArray();
+		}
 		try {
 			JsonElement element = jsonObject.get(memberName);
 			return element == null ? new JsonArray() : element.getAsJsonArray();

--- a/extension/src/main/java/org/operaton/bpm/extension/keycloak/plugin/KeycloakIdentityProviderPlugin.java
+++ b/extension/src/main/java/org/operaton/bpm/extension/keycloak/plugin/KeycloakIdentityProviderPlugin.java
@@ -32,11 +32,11 @@ import org.springframework.util.StringUtils;
  */
 public class KeycloakIdentityProviderPlugin extends KeycloakConfiguration implements ProcessEnginePlugin {
 
-	private final static KeycloakPluginLogger LOG = KeycloakPluginLogger.INSTANCE;
+	private static final KeycloakPluginLogger LOG = KeycloakPluginLogger.INSTANCE;
 	
 	private boolean authorizationEnabled;
 	
-	private KeycloakIdentityProviderFactory keycloakIdentityProviderFactory = null;
+	private KeycloakIdentityProviderFactory keycloakIdentityProviderFactory;
 
 	/** custom interceptors to modify behaviour of default KeycloakRestTemplate */
 	private List<ClientHttpRequestInterceptor> customHttpRequestInterceptors = Collections.emptyList();
@@ -52,13 +52,13 @@ public class KeycloakIdentityProviderPlugin extends KeycloakConfiguration implem
 
 		if (!StringUtils.isEmpty(administratorGroupName)) {
 			if (processEngineConfiguration.getAdminGroups() == null) {
-				processEngineConfiguration.setAdminGroups(new ArrayList<String>());
+				processEngineConfiguration.setAdminGroups(new ArrayList<>());
 			}
 			// add the configured administrator group to the engine configuration later: needs translation to group ID
 		}
 		if (!StringUtils.isEmpty(administratorUserId)) {
 			if (processEngineConfiguration.getAdminUsers() == null) {
-				processEngineConfiguration.setAdminUsers(new ArrayList<String>());
+				processEngineConfiguration.setAdminUsers(new ArrayList<>());
 			}
 			// add the configured administrator to the engine configuration later: potentially needs translation to user ID
 		}
@@ -163,7 +163,7 @@ public class KeycloakIdentityProviderPlugin extends KeycloakConfiguration implem
 			LOG.missingConfigurationParameter("charset");
 			missing.add("charset");
 		}
-		if (missing.size() > 0) {
+		if (!missing.isEmpty()) {
 			LOG.activationError(getClass().getSimpleName(), processEngineConfiguration.getProcessEngineName(),
 					"missing mandatory configuration parameters " + missing.toString());
 			throw new IllegalStateException("Unable to initialize plugin "

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/AbstractKeycloakIdentityProviderTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/AbstractKeycloakIdentityProviderTest.java
@@ -54,7 +54,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
 
 	// ------------------------------------------------------------------------
 	
-	private final static Logger LOG = BaseLogger.createLogger(
+	private static final Logger LOG = BaseLogger.createLogger(
 		      TestLogger.class, "KEYCLOAK", "org.operaton.bpm.extension.keycloak", "42").getLogger();
 	
 	protected static String GROUP_ID_TEAMLEAD;
@@ -78,7 +78,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
 	
 	private static final RestTemplate restTemplate = new RestTemplate();
 	
-	protected static String CLIENT_SECRET = null;
+	protected static String CLIENT_SECRET;
 	
 	// creates Keycloak setup only once per test run
 	static {
@@ -410,16 +410,18 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
 	    for (int i = 0; i < roleList.length(); i++) {
 	    	JSONObject role = roleList.getJSONObject(i);
 	    	String roleName = role.getString("name");
-	    	if (roleName.equals("query-users")) {
+	    	if ("query-users".equals(roleName)) {
 	    		queryUserRoleId = role.getString("id");
-	    	} else if (roleName.equals("query-groups")) {
+	    	} else if ("query-groups".equals(roleName)) {
 	    		queryGroupRoleId = role.getString("id");
-	    	} else if (roleName.equals("view-users")) {
+	    	} else if ("view-users".equals(roleName)) {
 	    		viewUserRoleId = role.getString("id");
-	    	} else if (roleName.equals("view-clients")) {
+	    	} else if ("view-clients".equals(roleName)) {
 	    		viewClientsRoleId = role.getString("id");
 	    	}
-	    	if (queryUserRoleId != null && queryGroupRoleId != null && viewUserRoleId != null && viewClientsRoleId != null) break;
+			if (queryUserRoleId != null && queryGroupRoleId != null && viewUserRoleId != null && viewClientsRoleId != null) {
+				break;
+			}
 	    }
 	    assertThat(queryUserRoleId, notNullValue());
 	    assertThat(queryGroupRoleId, notNullValue());
@@ -455,9 +457,15 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
 	static String createUser(HttpHeaders headers, String realm, String userName, String firstName, String lastName, String email, String password) throws JSONException {
 		// create user
 		StringBuffer userData = new StringBuffer( "{\"id\":null,\"username\":\""+ userName + "\",\"enabled\":true,\"totp\":false,\"emailVerified\":false,");
-		if (firstName != null) userData.append("\"firstName\":\"" + firstName + "\",");
-		if (lastName != null) userData.append("\"lastName\":\"" + lastName + "\",");
-		if (email != null) userData.append("\"email\":\"" + email + "\",");
+		if (firstName != null) {
+			userData.append("\"firstName\":\"" + firstName + "\",");
+		}
+		if (lastName != null) {
+			userData.append("\"lastName\":\"" + lastName + "\",");
+		}
+		if (email != null) {
+			userData.append("\"email\":\"" + email + "\",");
+		}
 		userData.append("\"disableableCredentialTypes\":[\"password\"],\"requiredActions\":[],\"federatedIdentities\":[],\"notBefore\":0,\"access\":{\"manageGroupMembership\":true,\"view\":true,\"mapRoles\":true,\"impersonate\":true,\"manage\":true}}");
 	    HttpEntity<String> request = new HttpEntity<>(userData.toString(), headers);
 	    ResponseEntity<String> response = restTemplate.postForEntity(KEYCLOAK_URL + "/admin/realms/" + realm + "/users", request, String.class);

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupAndUsePathAsId.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupAndUsePathAsId.java
@@ -45,9 +45,8 @@ public class KeycloakConfigureAdminGroupAndUsePathAsId extends AbstractKeycloakI
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 	}
 
 	// ------------------------------------------------------------------------

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupAsPath.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupAsPath.java
@@ -45,9 +45,8 @@ public class KeycloakConfigureAdminGroupAsPath extends AbstractKeycloakIdentityP
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 	}
 
 	// ------------------------------------------------------------------------

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupAsPathAndUsePathAsId.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupAsPathAndUsePathAsId.java
@@ -45,9 +45,8 @@ public class KeycloakConfigureAdminGroupAsPathAndUsePathAsId extends AbstractKey
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 	}
 
 	// ------------------------------------------------------------------------

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupTest.java
@@ -44,9 +44,8 @@ public class KeycloakConfigureAdminGroupTest extends AbstractKeycloakIdentityPro
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 	}
 
 	// ------------------------------------------------------------------------

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAndUseMailAsIdTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAndUseMailAsIdTest.java
@@ -44,9 +44,8 @@ public class KeycloakConfigureAdminUserIdAndUseMailAsIdTest extends AbstractKeyc
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 	}
 
 	// ------------------------------------------------------------------------

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAndUseUsernameAsIdTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAndUseUsernameAsIdTest.java
@@ -44,9 +44,8 @@ public class KeycloakConfigureAdminUserIdAndUseUsernameAsIdTest extends Abstract
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 	}
 
 	// ------------------------------------------------------------------------

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsMailTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsMailTest.java
@@ -44,9 +44,8 @@ public class KeycloakConfigureAdminUserIdAsMailTest extends AbstractKeycloakIden
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 	}
 
 	// ------------------------------------------------------------------------

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameAndUseMailAsIdTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameAndUseMailAsIdTest.java
@@ -44,9 +44,8 @@ public class KeycloakConfigureAdminUserIdAsUsernameAndUseMailAsIdTest extends Ab
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 	}
 
 	// ------------------------------------------------------------------------

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameAndUseUsernameAsIdTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameAndUseUsernameAsIdTest.java
@@ -44,9 +44,8 @@ public class KeycloakConfigureAdminUserIdAsUsernameAndUseUsernameAsIdTest extend
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 	}
 
 	// ------------------------------------------------------------------------

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameSimilarToClientName.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameSimilarToClientName.java
@@ -44,9 +44,8 @@ public class KeycloakConfigureAdminUserIdAsUsernameSimilarToClientName extends A
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 	}
 
 	// ------------------------------------------------------------------------

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameTest.java
@@ -44,9 +44,8 @@ public class KeycloakConfigureAdminUserIdAsUsernameTest extends AbstractKeycloak
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 	}
 
 	// ------------------------------------------------------------------------

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdTest.java
@@ -44,9 +44,8 @@ public class KeycloakConfigureAdminUserIdTest extends AbstractKeycloakIdentityPr
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 	}
 
 	// ------------------------------------------------------------------------

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTest.java
@@ -41,8 +41,8 @@ public class KeycloakGroupQueryTest extends AbstractKeycloakIdentityProviderTest
 		assertEquals(3, resultLast.size());
 
 		// unique results
-		assertEquals(0, result.stream().filter(group -> resultNext.contains(group)).count());
-		assertEquals(0, result.stream().filter(group -> resultLast.contains(group)).count());
+		assertEquals(0, result.stream().filter(resultNext::contains).count());
+		assertEquals(0, result.stream().filter(resultLast::contains).count());
 	}
 
 	public void testFilterByGroupId() {
@@ -102,7 +102,7 @@ public class KeycloakGroupQueryTest extends AbstractKeycloakIdentityProviderTest
 
 		assertEquals(2, groups.size());
 		for (Group group : groups) {
-			if (!group.getName().equals("operaton-admin") && !group.getName().equals("manager")) {
+			if (!"operaton-admin".equals(group.getName()) && !"manager".equals(group.getName())) {
 				fail();
 			}
 		}

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTestWithCaching.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTestWithCaching.java
@@ -40,9 +40,8 @@ public class KeycloakGroupQueryTestWithCaching extends AbstractKeycloakIdentityP
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 		this.clearCache();
 		CountingHttpRequestInterceptor.resetCount();
 	}
@@ -127,8 +126,8 @@ public class KeycloakGroupQueryTestWithCaching extends AbstractKeycloakIdentityP
 		assertEquals(3, resultLast.size());
 
 		// unique results
-		assertEquals(0, result.stream().filter(group -> resultNext.contains(group)).count());
-		assertEquals(0, result.stream().filter(group -> resultLast.contains(group)).count());
+		assertEquals(0, result.stream().filter(resultNext::contains).count());
+		assertEquals(0, result.stream().filter(resultLast::contains).count());
 	}
 
 	public void testCacheEnabledQueryOrderByGroupId() {

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTestWithCachingAndCustomCacheExpiry.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTestWithCachingAndCustomCacheExpiry.java
@@ -47,9 +47,8 @@ public class KeycloakGroupQueryTestWithCachingAndCustomCacheExpiry extends Abstr
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 		this.clearCache();
 		PredictableTicker.reset();
 		CountingHttpRequestInterceptor.resetCount();

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTestWithCachingAndMaxSize.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTestWithCachingAndMaxSize.java
@@ -46,9 +46,8 @@ public class KeycloakGroupQueryTestWithCachingAndMaxSize extends AbstractKeycloa
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 		this.clearCache();
 		CountingHttpRequestInterceptor.resetCount();
 	}

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakMassDataTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakMassDataTest.java
@@ -20,8 +20,8 @@ import junit.framework.TestSuite;
  */
 public class KeycloakMassDataTest extends AbstractKeycloakIdentityProviderTest {
 
-	static List<String> USER_IDS = new ArrayList<String>();
-	static List<String> GROUP_IDS = new ArrayList<String>();
+	static List<String> USER_IDS = new ArrayList<>();
+	static List<String> GROUP_IDS = new ArrayList<>();
 	
 	public static Test suite() {
 	    return new TestSetup(new TestSuite(KeycloakMassDataTest.class)) {

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakMaxResultSizeTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakMaxResultSizeTest.java
@@ -20,8 +20,8 @@ import junit.framework.TestSuite;
  */
 public class KeycloakMaxResultSizeTest extends AbstractKeycloakIdentityProviderTest {
 
-	static List<String> USER_IDS = new ArrayList<String>();
-	static List<String> GROUP_IDS = new ArrayList<String>();
+	static List<String> USER_IDS = new ArrayList<>();
+	static List<String> GROUP_IDS = new ArrayList<>();
 	
 	public static Test suite() {
 	    return new TestSetup(new TestSuite(KeycloakMaxResultSizeTest.class)) {

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakNestedGroupsQueryTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakNestedGroupsQueryTest.java
@@ -35,8 +35,8 @@ public class KeycloakNestedGroupsQueryTest extends AbstractKeycloakIdentityProvi
 	public void testGroupQueryFilterByUserId() {
 		List<Group> result = identityService.createGroupQuery().groupMember("johnfoo@gmail.com").list();
 		assertEquals(2, result.size());
-		assertEquals("expected johnfoo@gmail.com to member of group child2", 1, result.stream().filter(g -> g.getName().equals("child2")).count());
-		assertEquals("expected johnfoo@gmail.com to member of group subchild1", 1, result.stream().filter(g -> g.getName().equals("subchild1")).count());
+		assertEquals("expected johnfoo@gmail.com to member of group child2", 1, result.stream().filter(g -> "child2".equals(g.getName())).count());
+		assertEquals("expected johnfoo@gmail.com to member of group subchild1", 1, result.stream().filter(g -> "subchild1".equals(g.getName())).count());
 	}
 	
 	
@@ -45,8 +45,8 @@ public class KeycloakNestedGroupsQueryTest extends AbstractKeycloakIdentityProvi
 				.groupIdIn(GROUP_ID_ADMIN, GROUP_ID_HIERARCHY_CHILD1)
 				.list();
 		assertEquals(2, groups.size());
-		assertEquals("operaton-admin not found", 1, groups.stream().filter(g -> g.getName().equals("operaton-admin")).count());
-		assertEquals("child1 not found", 1, groups.stream().filter(g -> g.getName().equals("child1")).count());
+		assertEquals("operaton-admin not found", 1, groups.stream().filter(g -> "operaton-admin".equals(g.getName())).count());
+		assertEquals("child1 not found", 1, groups.stream().filter(g -> "child1".equals(g.getName())).count());
 	}
 
 	public void testGroupQueryFilterByGroupIdInAndUserId() {
@@ -68,14 +68,14 @@ public class KeycloakNestedGroupsQueryTest extends AbstractKeycloakIdentityProvi
 	public void testGroupQueryFilterByGroupNameLike() {
 		List<Group> result = identityService.createGroupQuery().groupNameLike("child*").list();
 		assertEquals(2, result.size());
-		assertEquals("expected group child1 to be included", 1, result.stream().filter(g -> g.getName().equals("child1")).count());
-		assertEquals("expected group child2 to be included", 1, result.stream().filter(g -> g.getName().equals("child2")).count());
+		assertEquals("expected group child1 to be included", 1, result.stream().filter(g -> "child1".equals(g.getName())).count());
+		assertEquals("expected group child2 to be included", 1, result.stream().filter(g -> "child2".equals(g.getName())).count());
 
 		result = identityService.createGroupQuery().groupNameLike("*child*").list();
 		assertEquals(3, result.size());
-		assertEquals("expected group child1 to be included", 1, result.stream().filter(g -> g.getName().equals("child1")).count());
-		assertEquals("expected group child2 to be included", 1, result.stream().filter(g -> g.getName().equals("child2")).count());
-		assertEquals("expected group subchild1 to be included", 1, result.stream().filter(g -> g.getName().equals("subchild1")).count());
+		assertEquals("expected group child1 to be included", 1, result.stream().filter(g -> "child1".equals(g.getName())).count());
+		assertEquals("expected group child2 to be included", 1, result.stream().filter(g -> "child2".equals(g.getName())).count());
+		assertEquals("expected group subchild1 to be included", 1, result.stream().filter(g -> "subchild1".equals(g.getName())).count());
 	}
 	
 	public void testGroupQueryFilterByGroupNameAndGroupNameLike() {
@@ -88,8 +88,8 @@ public class KeycloakNestedGroupsQueryTest extends AbstractKeycloakIdentityProvi
 	public void testGroupQueryFilterByGroupMember() {
 		List<Group> result = identityService.createGroupQuery().groupMember("johnfoo@gmail.com").list();
 		assertEquals(2, result.size());
-		assertEquals("expected johnfoo@gmail.com to member of group child2", 1, result.stream().filter(g -> g.getName().equals("child2")).count());
-		assertEquals("expected johnfoo@gmail.com to member of group subchild1", 1, result.stream().filter(g -> g.getName().equals("subchild1")).count());
+		assertEquals("expected johnfoo@gmail.com to member of group child2", 1, result.stream().filter(g -> "child2".equals(g.getName())).count());
+		assertEquals("expected johnfoo@gmail.com to member of group subchild1", 1, result.stream().filter(g -> "subchild1".equals(g.getName())).count());
 	}
 	
 	public void testUserQueryFilterByMemberOfGroup() {

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUseGroupPathdAsGroupIdQueryTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUseGroupPathdAsGroupIdQueryTest.java
@@ -73,7 +73,7 @@ public class KeycloakUseGroupPathdAsGroupIdQueryTest extends AbstractKeycloakIde
 		assertEquals(2, groups.size());
 		
 		for (Group group : groups) {
-			if (!group.getId().equals("root/child1/subchild1") && !group.getId().equals("root/child2")) {
+			if (!"root/child1/subchild1".equals(group.getId()) && !"root/child2".equals(group.getId())) {
 				fail();
 			}
 		}
@@ -98,7 +98,7 @@ public class KeycloakUseGroupPathdAsGroupIdQueryTest extends AbstractKeycloakIde
 
 		assertEquals(2, groups.size());
 		for (Group group : groups) {
-			if (!group.getName().equals("operaton-admin") && !group.getName().equals("manager")) {
+			if (!"operaton-admin".equals(group.getName()) && !"manager".equals(group.getName())) {
 				fail();
 			}
 		}
@@ -111,7 +111,7 @@ public class KeycloakUseGroupPathdAsGroupIdQueryTest extends AbstractKeycloakIde
 
 		assertEquals(2, groups.size());
 		for (Group group : groups) {
-			if (!group.getId().equals("root/child1/subchild1") && !group.getId().equals("root/child2")) {
+			if (!"root/child1/subchild1".equals(group.getId()) && !"root/child2".equals(group.getId())) {
 				fail();
 			}
 		}

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUseUsernameAsUserIdQueryTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUseUsernameAsUserIdQueryTest.java
@@ -20,7 +20,7 @@ import junit.framework.TestSuite;
  */
 public class KeycloakUseUsernameAsUserIdQueryTest extends AbstractKeycloakIdentityProviderTest {
 
-	static List<String> USER_IDS = new ArrayList<String>();
+	static List<String> USER_IDS = new ArrayList<>();
 
 	public static Test suite() {
 	    return new TestSetup(new TestSuite(KeycloakUseUsernameAsUserIdQueryTest.class)) {

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTest.java
@@ -38,7 +38,7 @@ public class KeycloakUserQueryTest extends AbstractKeycloakIdentityProviderTest 
 	  assertEquals(3, resultNext.size());
 	  
 	  // unique results
-	  assertEquals(0, result.stream().filter(user -> resultNext.contains(user)).count());
+	  assertEquals(0, result.stream().filter(resultNext::contains).count());
   }
 
   public void testFilterByUserId() {

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTestWithCaching.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTestWithCaching.java
@@ -40,9 +40,8 @@ public class KeycloakUserQueryTestWithCaching extends AbstractKeycloakIdentityPr
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 		this.clearCache();
 		CountingHttpRequestInterceptor.resetCount();
 	}
@@ -125,7 +124,7 @@ public class KeycloakUserQueryTestWithCaching extends AbstractKeycloakIdentityPr
 		assertEquals(3, resultNext.size());
 
 		// unique results
-		assertEquals(0, result.stream().filter(user -> resultNext.contains(user)).count());
+		assertEquals(0, result.stream().filter(resultNext::contains).count());
 	}
 
 	public void testCacheEnabledQueryOrderByUserId() {

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTestWithCachingAndCustomCacheExpiry.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTestWithCachingAndCustomCacheExpiry.java
@@ -47,9 +47,8 @@ public class KeycloakUserQueryTestWithCachingAndCustomCacheExpiry extends Abstra
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 		this.clearCache();
 		PredictableTicker.reset();
 		CountingHttpRequestInterceptor.resetCount();

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTestWithCachingAndMaxSize.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTestWithCachingAndMaxSize.java
@@ -47,9 +47,8 @@ public class KeycloakUserQueryTestWithCachingAndMaxSize extends AbstractKeycloak
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		// delete all created authorizations
-		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a -> {
-			processEngine.getAuthorizationService().deleteAuthorization(a.getId());
-		});
+		processEngine.getAuthorizationService().createAuthorizationQuery().list().forEach(a ->
+			processEngine.getAuthorizationService().deleteAuthorization(a.getId()));
 		this.clearCache();
 		PredictableTicker.reset();
 		CountingHttpRequestInterceptor.resetCount();


### PR DESCRIPTION
Applied OpenRewrite recipe org.openrewrite.staticanalysis.CommonStaticAnalysis

Changes:
- remove obsolete field initialization:
 - removed `= false` from boolean fields
 - removed `= null` from object fields
- encapsulate single-line if-statements in blocks {}
- make classes final:
  - CacheableKeycloakGroupQuery
  - CacheableKeycloakUserQuery
  - CacheConfiguration
- add `final` to fields that are initialized by constructor only
- lambdas:
  - remove unnecessary blocks
  - use method references
- change order `final static` to recommended `static final`
- remove obsolete types in qualified
- inverse order of string equals with constants
- replace List::size>0 by isEmpty

