### PR TITLE
Refactor/rename non final fields; Remove unnecessary throws declarations

### DIFF
--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/AbstractKeycloakIdentityProviderTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/AbstractKeycloakIdentityProviderTest.java
@@ -61,28 +61,28 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
   private static final Logger LOG = BaseLogger.createLogger(TestLogger.class, "KEYCLOAK",
       "org.operaton.bpm.extension.keycloak", "42").getLogger();
 
-  protected static String GROUP_ID_TEAMLEAD;
-  protected static String GROUP_ID_MANAGER;
-  protected static String GROUP_ID_ADMIN;
-  protected static String GROUP_ID_SYSTEM_READONLY;
+  protected static String groupIdTeamlead;
+  protected static String groupIdManager;
+  protected static String groupIdAdmin;
+  protected static String groupIdSystemReadonly;
 
-  protected static String USER_ID_OPERATON_ADMIN;
-  protected static String USER_ID_TEAMLEAD;
-  protected static String USER_ID_MANAGER;
+  protected static String userIdOperatonAdmin;
+  protected static String userIdTeamlead;
+  protected static String userIdManager;
 
-  protected static String GROUP_ID_HIERARCHY_ROOT;
-  protected static String GROUP_ID_HIERARCHY_CHILD1;
-  protected static String GROUP_ID_HIERARCHY_CHILD2;
-  protected static String GROUP_ID_HIERARCHY_SUBCHILD1;
+  protected static String groupIdHierarchyRoot;
+  protected static String groupIdHierarchyChild1;
+  protected static String groupIdHierarchyChild2;
+  protected static String groupIdHierarchySubchild1;
 
-  protected static String USER_ID_HIERARCHY;
+  protected static String userIdHierarchy;
 
-  protected static String GROUP_ID_SIMILAR_CLIENT_NAME;
-  protected static String USER_ID_SIMILAR_CLIENT_NAME;
+  protected static String groupIdSimilarClientName;
+  protected static String userIdSimilarClientName;
 
-  private static final RestTemplate restTemplate = new RestTemplate();
+  private static final RestTemplate REST_TEMPLATE = new RestTemplate();
 
-  protected static String CLIENT_SECRET;
+  protected static String clientSecret;
 
   @Container
   static KeycloakContainer keycloak = new KeycloakContainer("quay.io/keycloak/keycloak:26.0.7");
@@ -179,7 +179,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
         kcp.setKeycloakAdminUrl(kcp.getKeycloakAdminUrl().replace("http://localhost:9000", keycloakUrl));
         kcp.setKeycloakIssuerUrl(kcp.getKeycloakIssuerUrl().replace("http://localhost:9000", keycloakUrl));
         kcp.setEnforceSubgroupsInGroupQuery(keycloakEnforceSubgroupsInGroupQuery);
-        kcp.setClientSecret(CLIENT_SECRET);
+        kcp.setClientSecret(clientSecret);
         return kcp;
       }
     }
@@ -222,45 +222,45 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
     createRealm(headers, realm);
 
     // Create Client
-    CLIENT_SECRET = createClient(headers, realm, "operaton-identity-service", "http://localhost:8080/login");
+    clientSecret = createClient(headers, realm, "operaton-identity-service", "http://localhost:8080/login");
 
     // Create groups
-    GROUP_ID_ADMIN = createGroup(headers, realm, "operaton-admin", true);
-    GROUP_ID_TEAMLEAD = createGroup(headers, realm, "teamlead", false);
-    GROUP_ID_MANAGER = createGroup(headers, realm, "manager", false);
-    GROUP_ID_SYSTEM_READONLY = createGroup(headers, realm, "cam-read-only", true);
+    groupIdAdmin = createGroup(headers, realm, "operaton-admin", true);
+    groupIdTeamlead = createGroup(headers, realm, "teamlead", false);
+    groupIdManager = createGroup(headers, realm, "manager", false);
+    groupIdSystemReadonly = createGroup(headers, realm, "cam-read-only", true);
 
     // Create Users
-    USER_ID_OPERATON_ADMIN = createUser(headers, realm, "operaton", "Admin", "Operaton", "operaton@accso.de",
+    userIdOperatonAdmin = createUser(headers, realm, "operaton", "Admin", "Operaton", "operaton@accso.de",
         "operaton1!");
-    assignUserGroup(headers, realm, USER_ID_OPERATON_ADMIN, GROUP_ID_ADMIN);
+    assignUserGroup(headers, realm, userIdOperatonAdmin, groupIdAdmin);
 
-    USER_ID_TEAMLEAD = createUser(headers, realm, "hans.mustermann", "Hans", "Mustermann",
+    userIdTeamlead = createUser(headers, realm, "hans.mustermann", "Hans", "Mustermann",
         "hans.mustermann@tradermail.info", "äöüÄÖÜ");
-    assignUserGroup(headers, realm, USER_ID_TEAMLEAD, GROUP_ID_TEAMLEAD);
+    assignUserGroup(headers, realm, userIdTeamlead, groupIdTeamlead);
 
-    USER_ID_MANAGER = createUser(headers, realm, "gunnar.von-der-beck@accso.de", "Gunnar", "von der Beck",
+    userIdManager = createUser(headers, realm, "gunnar.von-der-beck@accso.de", "Gunnar", "von der Beck",
         "gunnar.von-der-beck@accso.de", null);
-    assignUserGroup(headers, realm, USER_ID_MANAGER, GROUP_ID_MANAGER);
-    assignUserGroup(headers, realm, USER_ID_MANAGER, GROUP_ID_TEAMLEAD);
+    assignUserGroup(headers, realm, userIdManager, groupIdManager);
+    assignUserGroup(headers, realm, userIdManager, groupIdTeamlead);
 
     // Create additional group hierarchy
-    GROUP_ID_HIERARCHY_ROOT = createGroup(headers, realm, "root", false);
-    GROUP_ID_HIERARCHY_CHILD1 = createGroup(headers, realm, "child1", false, GROUP_ID_HIERARCHY_ROOT);
-    GROUP_ID_HIERARCHY_CHILD2 = createGroup(headers, realm, "child2", false, GROUP_ID_HIERARCHY_ROOT);
-    GROUP_ID_HIERARCHY_SUBCHILD1 = createGroup(headers, realm, "subchild1", false, GROUP_ID_HIERARCHY_CHILD1);
+    groupIdHierarchyRoot = createGroup(headers, realm, "root", false);
+    groupIdHierarchyChild1 = createGroup(headers, realm, "child1", false, groupIdHierarchyRoot);
+    groupIdHierarchyChild2 = createGroup(headers, realm, "child2", false, groupIdHierarchyRoot);
+    groupIdHierarchySubchild1 = createGroup(headers, realm, "subchild1", false, groupIdHierarchyChild1);
 
     // Create user with access to parts of hierarchy
-    USER_ID_HIERARCHY = createUser(headers, realm, "johnfoo", "John", "Foo", "johnfoo@gmail.com",
+    userIdHierarchy = createUser(headers, realm, "johnfoo", "John", "Foo", "johnfoo@gmail.com",
         "!§$%&/()=?#'-_.:,;+*~@€");
-    assignUserGroup(headers, realm, USER_ID_HIERARCHY, GROUP_ID_HIERARCHY_CHILD2);
-    assignUserGroup(headers, realm, USER_ID_HIERARCHY, GROUP_ID_HIERARCHY_SUBCHILD1);
+    assignUserGroup(headers, realm, userIdHierarchy, groupIdHierarchyChild2);
+    assignUserGroup(headers, realm, userIdHierarchy, groupIdHierarchySubchild1);
 
     // Create user and group named similar to the name of the Keycloak Client
-    GROUP_ID_SIMILAR_CLIENT_NAME = createGroup(headers, realm, "operaton-identity-service", false);
-    USER_ID_SIMILAR_CLIENT_NAME = createUser(headers, realm, "operaton-identity-service", "Identity", "Service",
+    groupIdSimilarClientName = createGroup(headers, realm, "operaton-identity-service", false);
+    userIdSimilarClientName = createUser(headers, realm, "operaton-identity-service", "Identity", "Service",
         "identity.service@test.de", null);
-    assignUserGroup(headers, realm, USER_ID_SIMILAR_CLIENT_NAME, GROUP_ID_SIMILAR_CLIENT_NAME);
+    assignUserGroup(headers, realm, userIdSimilarClientName, groupIdSimilarClientName);
 
     // --------------------------------------------------------------------
 
@@ -272,11 +272,11 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
     createClientRole(headers, realm, clientInternalId, "role-manager");
 
     // Add Client level roles to groups and users
-    addGroupClientRoleMapping(headers, realm, GROUP_ID_ADMIN, clientInternalId, "role-admin");
-    addGroupClientRoleMapping(headers, realm, GROUP_ID_TEAMLEAD, clientInternalId, "role-teamlead");
-    addGroupClientRoleMapping(headers, realm, GROUP_ID_MANAGER, clientInternalId, "role-manager");
-    addUserClientRoleMapping(headers, realm, USER_ID_TEAMLEAD, clientInternalId, "role-readonly");
-    addUserClientRoleMapping(headers, realm, USER_ID_MANAGER, clientInternalId, "role-readonly");
+    addGroupClientRoleMapping(headers, realm, groupIdAdmin, clientInternalId, "role-admin");
+    addGroupClientRoleMapping(headers, realm, groupIdTeamlead, clientInternalId, "role-teamlead");
+    addGroupClientRoleMapping(headers, realm, groupIdManager, clientInternalId, "role-manager");
+    addUserClientRoleMapping(headers, realm, userIdTeamlead, clientInternalId, "role-readonly");
+    addUserClientRoleMapping(headers, realm, userIdManager, clientInternalId, "role-readonly");
   }
 
   /**
@@ -315,11 +315,11 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
         .setConnectionManager(connectionManagerBuilder.build())
         .build();
     final HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(httpClient);
-    restTemplate.setRequestFactory(factory);
+    REST_TEMPLATE.setRequestFactory(factory);
 
-    for (int i = 0; i < restTemplate.getMessageConverters().size(); i++) {
-      if (restTemplate.getMessageConverters().get(i) instanceof StringHttpMessageConverter) {
-        restTemplate.getMessageConverters().set(i, new StringHttpMessageConverter(StandardCharsets.UTF_8));
+    for (int i = 0; i < REST_TEMPLATE.getMessageConverters().size(); i++) {
+      if (REST_TEMPLATE.getMessageConverters().get(i) instanceof StringHttpMessageConverter) {
+        REST_TEMPLATE.getMessageConverters().set(i, new StringHttpMessageConverter(StandardCharsets.UTF_8));
         break;
       }
     }
@@ -338,7 +338,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
     HttpEntity<String> request = new HttpEntity<>(
         "client_id=admin-cli" + "&username=" + keycloakAdminUser + "&password=" + keycloakAdminPassword
             + "&grant_type=password", headers);
-    ResponseEntity<String> response = restTemplate.postForEntity(
+    ResponseEntity<String> response = REST_TEMPLATE.postForEntity(
         keycloakUrl + "/realms/master/protocol/openid-connect/token", request, String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     JSONObject json = new JSONObject(response.getBody());
@@ -364,7 +364,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
     String realmData = "{\"id\":null,\"realm\":\"" + realm
         + "\",\"notBefore\":0,\"revokeRefreshToken\":false,\"refreshTokenMaxReuse\":0,\"accessTokenLifespan\":300,\"accessTokenLifespanForImplicitFlow\":900,\"ssoSessionIdleTimeout\":1800,\"ssoSessionMaxLifespan\":36000,\"ssoSessionIdleTimeoutRememberMe\":0,\"ssoSessionMaxLifespanRememberMe\":0,\"offlineSessionIdleTimeout\":2592000,\"offlineSessionMaxLifespanEnabled\":false,\"offlineSessionMaxLifespan\":5184000,\"accessCodeLifespan\":60,\"accessCodeLifespanUserAction\":300,\"accessCodeLifespanLogin\":1800,\"actionTokenGeneratedByAdminLifespan\":43200,\"actionTokenGeneratedByUserLifespan\":300,\"enabled\":true,\"sslRequired\":\"external\",\"registrationAllowed\":false,\"registrationEmailAsUsername\":false,\"rememberMe\":false,\"verifyEmail\":false,\"loginWithEmailAllowed\":true,\"duplicateEmailsAllowed\":false,\"resetPasswordAllowed\":false,\"editUsernameAllowed\":false,\"bruteForceProtected\":false,\"permanentLockout\":false,\"maxFailureWaitSeconds\":900,\"minimumQuickLoginWaitSeconds\":60,\"waitIncrementSeconds\":60,\"quickLoginCheckMilliSeconds\":1000,\"maxDeltaTimeSeconds\":43200,\"failureFactor\":30,\"defaultRoles\":[\"uma_authorization\",\"offline_access\"],\"requiredCredentials\":[\"password\"],\"otpPolicyType\":\"totp\",\"otpPolicyAlgorithm\":\"HmacSHA1\",\"otpPolicyInitialCounter\":0,\"otpPolicyDigits\":6,\"otpPolicyLookAheadWindow\":1,\"otpPolicyPeriod\":30,\"otpSupportedApplications\":[\"FreeOTP\",\"Google Authenticator\"],\"browserSecurityHeaders\":{\"contentSecurityPolicyReportOnly\":\"\",\"xContentTypeOptions\":\"nosniff\",\"xRobotsTag\":\"none\",\"xFrameOptions\":\"SAMEORIGIN\",\"xXSSProtection\":\"1; mode=block\",\"contentSecurityPolicy\":\"frame-src 'self'; frame-ancestors 'self'; object-src 'none';\",\"strictTransportSecurity\":\"max-age=31536000; includeSubDomains\"},\"smtpServer\":{},\"eventsEnabled\":false,\"eventsListeners\":[\"jboss-logging\"],\"enabledEventTypes\":[],\"adminEventsEnabled\":false,\"adminEventsDetailsEnabled\":false,\"internationalizationEnabled\":false,\"supportedLocales\":[],\"browserFlow\":\"browser\",\"registrationFlow\":\"registration\",\"directGrantFlow\":\"direct grant\",\"resetCredentialsFlow\":\"reset credentials\",\"clientAuthenticationFlow\":\"clients\",\"dockerAuthenticationFlow\":\"docker auth\",\"attributes\":{\"_browser_header.xXSSProtection\":\"1; mode=block\",\"_browser_header.xFrameOptions\":\"SAMEORIGIN\",\"_browser_header.strictTransportSecurity\":\"max-age=31536000; includeSubDomains\",\"permanentLockout\":\"false\",\"quickLoginCheckMilliSeconds\":\"1000\",\"_browser_header.xRobotsTag\":\"none\",\"maxFailureWaitSeconds\":\"900\",\"minimumQuickLoginWaitSeconds\":\"60\",\"failureFactor\":\"30\",\"actionTokenGeneratedByUserLifespan\":\"300\",\"maxDeltaTimeSeconds\":\"43200\",\"_browser_header.xContentTypeOptions\":\"nosniff\",\"offlineSessionMaxLifespan\":\"5184000\",\"actionTokenGeneratedByAdminLifespan\":\"43200\",\"_browser_header.contentSecurityPolicyReportOnly\":\"\",\"bruteForceProtected\":\"false\",\"_browser_header.contentSecurityPolicy\":\"frame-src 'self'; frame-ancestors 'self'; object-src 'none';\",\"waitIncrementSeconds\":\"60\",\"offlineSessionMaxLifespanEnabled\":\"false\"},\"userManagedAccessAllowed\":false}";
     HttpEntity<String> request = new HttpEntity<>(realmData, headers);
-    ResponseEntity<String> response = restTemplate.postForEntity(keycloakUrl + "/admin/realms", request, String.class);
+    ResponseEntity<String> response = REST_TEMPLATE.postForEntity(keycloakUrl + "/admin/realms", request, String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     LOG.info("Created realm " + realm);
   }
@@ -376,7 +376,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
    * @param realm   the realm name
    */
   private static void deleteRealm(HttpHeaders headers, String realm) {
-    ResponseEntity<String> response = restTemplate.exchange(keycloakUrl + "/admin/realms/" + realm, HttpMethod.DELETE,
+    ResponseEntity<String> response = REST_TEMPLATE.exchange(keycloakUrl + "/admin/realms/" + realm, HttpMethod.DELETE,
         new HttpEntity<>(headers), String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     LOG.info("Deleted realm " + realm);
@@ -400,17 +400,17 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
         + redirectUri
         + "\"],\"webOrigins\":[],\"notBefore\":0,\"bearerOnly\":false,\"consentRequired\":false,\"standardFlowEnabled\":true,\"implicitFlowEnabled\":false,\"directAccessGrantsEnabled\":true,\"serviceAccountsEnabled\":true,\"publicClient\":false,\"frontchannelLogout\":false,\"protocol\":\"openid-connect\",\"attributes\":{\"client_credentials.use_refresh_token\":\"true\",\"saml.assertion.signature\":\"false\",\"saml.force.post.binding\":\"false\",\"saml.multivalued.roles\":\"false\",\"saml.encrypt\":\"false\",\"saml.server.signature\":\"false\",\"saml.server.signature.keyinfo.ext\":\"false\",\"exclude.session.state.from.auth.response\":\"false\",\"saml_force_name_id_format\":\"false\",\"saml.client.signature\":\"false\",\"tls.client.certificate.bound.access.tokens\":\"false\",\"saml.authnstatement\":\"false\",\"display.on.consent.screen\":\"false\",\"saml.onetimeuse.condition\":\"false\"},\"authenticationFlowBindingOverrides\":{},\"fullScopeAllowed\":true,\"nodeReRegistrationTimeout\":-1,\"protocolMappers\":[{\"id\":null,\"name\":\"Client Host\",\"protocol\":\"openid-connect\",\"protocolMapper\":\"oidc-usersessionmodel-note-mapper\",\"consentRequired\":false,\"config\":{\"user.session.note\":\"clientHost\",\"userinfo.token.claim\":\"true\",\"id.token.claim\":\"true\",\"access.token.claim\":\"true\",\"claim.name\":\"clientHost\",\"jsonType.label\":\"String\"}},{\"id\":null,\"name\":\"Client IP Address\",\"protocol\":\"openid-connect\",\"protocolMapper\":\"oidc-usersessionmodel-note-mapper\",\"consentRequired\":false,\"config\":{\"user.session.note\":\"clientAddress\",\"userinfo.token.claim\":\"true\",\"id.token.claim\":\"true\",\"access.token.claim\":\"true\",\"claim.name\":\"clientAddress\",\"jsonType.label\":\"String\"}},{\"id\":null,\"name\":\"Client ID\",\"protocol\":\"openid-connect\",\"protocolMapper\":\"oidc-usersessionmodel-note-mapper\",\"consentRequired\":false,\"config\":{\"user.session.note\":\"clientId\",\"userinfo.token.claim\":\"true\",\"id.token.claim\":\"true\",\"access.token.claim\":\"true\",\"claim.name\":\"clientId\",\"jsonType.label\":\"String\"}}],\"defaultClientScopes\":[\"web-origins\",\"role_list\",\"profile\",\"roles\",\"email\"],\"optionalClientScopes\":[\"address\",\"phone\",\"offline_access\"],\"access\":{\"view\":true,\"configure\":true,\"manage\":true}}";
     HttpEntity<String> request = new HttpEntity<>(clientData, headers);
-    ResponseEntity<String> response = restTemplate.postForEntity(keycloakUrl + "/admin/realms/" + realm + "/clients",
+    ResponseEntity<String> response = REST_TEMPLATE.postForEntity(keycloakUrl + "/admin/realms/" + realm + "/clients",
         request, String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 
     // Get the Client secret
     String clientSecret = null;
-    response = restTemplate.exchange(keycloakUrl + "/admin/realms/" + realm + "/clients?clientId=" + clientId,
+    response = REST_TEMPLATE.exchange(keycloakUrl + "/admin/realms/" + realm + "/clients?clientId=" + clientId,
         HttpMethod.GET, new HttpEntity<>(headers), String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     String internalClientId = new JSONArray(response.getBody()).getJSONObject(0).getString("id");
-    response = restTemplate.exchange(
+    response = REST_TEMPLATE.exchange(
         keycloakUrl + "/admin/realms/" + realm + "/clients/" + internalClientId + "/client-secret", HttpMethod.GET,
         new HttpEntity<>(headers), String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -418,7 +418,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
     assertThat(clientSecret).isNotNull();
 
     // Get the Client's service account
-    response = restTemplate.exchange(
+    response = REST_TEMPLATE.exchange(
         keycloakUrl + "/admin/realms/" + realm + "/users?username=service-account-" + clientId, HttpMethod.GET,
         new HttpEntity<>(headers), String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -429,11 +429,11 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
     String queryGroupRoleId = null;
     String viewUserRoleId = null;
     String viewClientsRoleId = null;
-    response = restTemplate.exchange(keycloakUrl + "/admin/realms/" + realm + "/clients?clientId=realm-management",
+    response = REST_TEMPLATE.exchange(keycloakUrl + "/admin/realms/" + realm + "/clients?clientId=realm-management",
         HttpMethod.GET, new HttpEntity<>(headers), String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     String realmManagementId = new JSONArray(response.getBody()).getJSONObject(0).getString("id");
-    response = restTemplate.exchange(
+    response = REST_TEMPLATE.exchange(
         keycloakUrl + "/admin/realms/" + realm + "/users/" + serviceAccountId + "/role-mappings/clients/"
             + realmManagementId + "/available", HttpMethod.GET, new HttpEntity<>(headers), String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -469,7 +469,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
         + "\",\"description\":\"${role_view-clients}\",\"id\":\"" + viewClientsRoleId + "\",\"name\":\"view-clients\"}"
         + "]";
     request = new HttpEntity<>(roleMapping, headers);
-    response = restTemplate.postForEntity(
+    response = REST_TEMPLATE.postForEntity(
         keycloakUrl + "/admin/realms/" + realm + "/users/" + serviceAccountId + "/role-mappings/clients/"
             + realmManagementId, request, String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
@@ -513,18 +513,18 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
     userData.append(
         "\"disableableCredentialTypes\":[\"password\"],\"requiredActions\":[],\"federatedIdentities\":[],\"notBefore\":0,\"access\":{\"manageGroupMembership\":true,\"view\":true,\"mapRoles\":true,\"impersonate\":true,\"manage\":true}}");
     HttpEntity<String> request = new HttpEntity<>(userData.toString(), headers);
-    ResponseEntity<String> response = restTemplate.postForEntity(keycloakUrl + "/admin/realms/" + realm + "/users",
+    ResponseEntity<String> response = REST_TEMPLATE.postForEntity(keycloakUrl + "/admin/realms/" + realm + "/users",
         request, String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     // get the user ID
-    response = restTemplate.exchange(keycloakUrl + "/admin/realms/" + realm + "/users?username=" + userName,
+    response = REST_TEMPLATE.exchange(keycloakUrl + "/admin/realms/" + realm + "/users?username=" + userName,
         HttpMethod.GET, new HttpEntity<>(headers), String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     String userId = new JSONArray(response.getBody()).getJSONObject(0).getString("id");
     // set optional password
     if (!ObjectUtils.isEmpty(password)) {
       String pwd = "{\"type\":\"password\",\"value\":\"" + password + "\"}";
-      response = restTemplate.exchange(keycloakUrl + "/admin/realms/" + realm + "/users/" + userId + "/reset-password",
+      response = REST_TEMPLATE.exchange(keycloakUrl + "/admin/realms/" + realm + "/users/" + userId + "/reset-password",
           HttpMethod.PUT, new HttpEntity<>(pwd, headers), String.class);
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     }
@@ -540,7 +540,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
    * @param userId  the user ID
    */
   static void deleteUser(HttpHeaders headers, String realm, String userId) {
-    ResponseEntity<String> response = restTemplate.exchange(keycloakUrl + "/admin/realms/" + realm + "/users/" + userId,
+    ResponseEntity<String> response = REST_TEMPLATE.exchange(keycloakUrl + "/admin/realms/" + realm + "/users/" + userId,
         HttpMethod.DELETE, new HttpEntity<>(headers), String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     LOG.info("Deleted user with ID {}", userId);
@@ -583,13 +583,13 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
         "{\"id\":null,\"name\":\"" + groupName + "\",\"attributes\":{" + (isSystemGroup ? "\"type\":[\"SYSTEM\"]" : "")
             + "},\"realmRoles\":[],\"clientRoles\":{},\"subGroups\":[],\"access\":{\"view\":true,\"manage\":true,\"manageMembership\":true}}";
     HttpEntity<String> request = new HttpEntity<>(operatonAdmin, headers);
-    ResponseEntity<String> response = restTemplate.postForEntity(keycloakUrl + "/admin/realms/" + realm + "/groups" + (
+    ResponseEntity<String> response = REST_TEMPLATE.postForEntity(keycloakUrl + "/admin/realms/" + realm + "/groups" + (
         parentGroupId != null ?
             "/" + parentGroupId + "/children" :
             ""), request, String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     // get the group id
-    response = restTemplate.exchange(keycloakUrl + "/admin/realms/" + realm + "/groups?search=" + groupName,
+    response = REST_TEMPLATE.exchange(keycloakUrl + "/admin/realms/" + realm + "/groups?search=" + groupName,
         HttpMethod.GET, new HttpEntity<>(headers), String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     JSONArray groups = new JSONArray(response.getBody());
@@ -608,7 +608,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
    * @param groupId the group ID
    */
   static void deleteGroup(HttpHeaders headers, String realm, String groupId) {
-    ResponseEntity<String> response = restTemplate.exchange(
+    ResponseEntity<String> response = REST_TEMPLATE.exchange(
         keycloakUrl + "/admin/realms/" + realm + "/groups/" + groupId, HttpMethod.DELETE, new HttpEntity<>(headers),
         String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
@@ -639,7 +639,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
    * @param groupId the group ID
    */
   static void assignUserGroup(HttpHeaders headers, String realm, String userId, String groupId) {
-    ResponseEntity<String> response = restTemplate.exchange(
+    ResponseEntity<String> response = REST_TEMPLATE.exchange(
         keycloakUrl + "/admin/realms/" + realm + "/users/" + userId + "/groups/" + groupId, HttpMethod.PUT,
         new HttpEntity<>(headers), String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
@@ -659,7 +659,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
    * @throws JSONException in case of any errors
    */
   static String getClientInternalId(HttpHeaders headers, String realm, String clientId) throws JSONException {
-    ResponseEntity<String> response = restTemplate.exchange(
+    ResponseEntity<String> response = REST_TEMPLATE.exchange(
         keycloakUrl + "/admin/realms/" + realm + "/clients?clientId=" + clientId, HttpMethod.GET,
         new HttpEntity<>(null, headers), String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -678,7 +678,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
   static void createClientRole(HttpHeaders headers, String realm, String clientInternalId, String roleName) {
     String role = "{\"name\":\"" + roleName + "\"}";
     HttpEntity<String> request = new HttpEntity<>(role, headers);
-    ResponseEntity<String> response = restTemplate.postForEntity(
+    ResponseEntity<String> response = REST_TEMPLATE.postForEntity(
         keycloakUrl + "/admin/realms/" + realm + "/clients/" + clientInternalId + "/roles", request, String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     LOG.info("Created client role {}", roleName);
@@ -700,7 +700,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
                                        String clientInternalId,
                                        String roleName) throws JSONException {
     // get internal ID of client role
-    ResponseEntity<String> response = restTemplate.exchange(
+    ResponseEntity<String> response = REST_TEMPLATE.exchange(
         keycloakUrl + "/admin/realms/" + realm + "/clients/" + clientInternalId + "/roles/" + roleName, HttpMethod.GET,
         new HttpEntity<>(headers), String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -710,7 +710,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
     String mapping = "[{\"id\":\"" + roleId + "\",\"name\":\"" + roleName
         + "\",\"composite\":false,\"clientRole\":true,\"containerId\":\"" + clientInternalId + "\"}]";
     HttpEntity<String> request = new HttpEntity<>(mapping, headers);
-    response = restTemplate.postForEntity(
+    response = REST_TEMPLATE.postForEntity(
         keycloakUrl + "/admin/realms/" + realm + "/users/" + userId + "/role-mappings/clients/" + clientInternalId,
         request, String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
@@ -732,7 +732,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
                                         String clientInternalId,
                                         String roleName) throws JSONException {
     // get internal ID of client role
-    ResponseEntity<String> response = restTemplate.exchange(
+    ResponseEntity<String> response = REST_TEMPLATE.exchange(
         keycloakUrl + "/admin/realms/" + realm + "/clients/" + clientInternalId + "/roles/" + roleName, HttpMethod.GET,
         new HttpEntity<>(headers), String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -742,7 +742,7 @@ public abstract class AbstractKeycloakIdentityProviderTest extends PluggableProc
     String mapping = "[{\"id\":\"" + roleId + "\",\"name\":\"" + roleName
         + "\",\"composite\":false,\"clientRole\":true,\"containerId\":\"" + clientInternalId + "\"}]";
     HttpEntity<String> request = new HttpEntity<>(mapping, headers);
-    response = restTemplate.postForEntity(
+    response = REST_TEMPLATE.postForEntity(
         keycloakUrl + "/admin/realms/" + realm + "/groups/" + groupId + "/role-mappings/clients/" + clientInternalId,
         request, String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupAndUsePathAsId.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupAndUsePathAsId.java
@@ -25,7 +25,7 @@ public class KeycloakConfigureAdminGroupAndUsePathAsId extends AbstractKeycloakI
     return new TestSetup(new TestSuite(KeycloakConfigureAdminGroupAndUsePathAsId.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureAdminGroupAndUsePathAsId.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config);
@@ -33,7 +33,7 @@ public class KeycloakConfigureAdminGroupAndUsePathAsId extends AbstractKeycloakI
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupAsPath.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupAsPath.java
@@ -25,7 +25,7 @@ public class KeycloakConfigureAdminGroupAsPath extends AbstractKeycloakIdentityP
     return new TestSetup(new TestSuite(KeycloakConfigureAdminGroupAsPath.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureAdminGroupAsPath.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config);
@@ -33,7 +33,7 @@ public class KeycloakConfigureAdminGroupAsPath extends AbstractKeycloakIdentityP
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupAsPathAndUsePathAsId.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupAsPathAndUsePathAsId.java
@@ -25,7 +25,7 @@ public class KeycloakConfigureAdminGroupAsPathAndUsePathAsId extends AbstractKey
     return new TestSetup(new TestSuite(KeycloakConfigureAdminGroupAsPathAndUsePathAsId.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureAdminGroupAsPathAndUsePathAsId.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config);
@@ -33,7 +33,7 @@ public class KeycloakConfigureAdminGroupAsPathAndUsePathAsId extends AbstractKey
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminGroupTest.java
@@ -24,7 +24,7 @@ public class KeycloakConfigureAdminGroupTest extends AbstractKeycloakIdentityPro
     return new TestSetup(new TestSuite(KeycloakConfigureAdminGroupTest.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureAdminGroup.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config);
@@ -32,7 +32,7 @@ public class KeycloakConfigureAdminGroupTest extends AbstractKeycloakIdentityPro
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAndUseMailAsIdTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAndUseMailAsIdTest.java
@@ -24,7 +24,7 @@ public class KeycloakConfigureAdminUserIdAndUseMailAsIdTest extends AbstractKeyc
     return new TestSetup(new TestSuite(KeycloakConfigureAdminUserIdAndUseMailAsIdTest.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureAdminUserIdAndUseMailAsId.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config).setAdministratorUserId(userIdOperatonAdmin);
@@ -32,7 +32,7 @@ public class KeycloakConfigureAdminUserIdAndUseMailAsIdTest extends AbstractKeyc
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAndUseMailAsIdTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAndUseMailAsIdTest.java
@@ -27,7 +27,7 @@ public class KeycloakConfigureAdminUserIdAndUseMailAsIdTest extends AbstractKeyc
       protected void setUp() throws Exception {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureAdminUserIdAndUseMailAsId.cfg.xml");
-        configureKeycloakIdentityProviderPlugin(config).setAdministratorUserId(USER_ID_OPERATON_ADMIN);
+        configureKeycloakIdentityProviderPlugin(config).setAdministratorUserId(userIdOperatonAdmin);
         PluggableProcessEngineTestCase.cachedProcessEngine = config.buildProcessEngine();
       }
 

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAndUseUsernameAsIdTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAndUseUsernameAsIdTest.java
@@ -24,7 +24,7 @@ public class KeycloakConfigureAdminUserIdAndUseUsernameAsIdTest extends Abstract
     return new TestSetup(new TestSuite(KeycloakConfigureAdminUserIdAndUseUsernameAsIdTest.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureAdminUserIdAndUseUsernameAsId.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config).setAdministratorUserId(userIdOperatonAdmin);
@@ -32,7 +32,7 @@ public class KeycloakConfigureAdminUserIdAndUseUsernameAsIdTest extends Abstract
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAndUseUsernameAsIdTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAndUseUsernameAsIdTest.java
@@ -27,7 +27,7 @@ public class KeycloakConfigureAdminUserIdAndUseUsernameAsIdTest extends Abstract
       protected void setUp() throws Exception {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureAdminUserIdAndUseUsernameAsId.cfg.xml");
-        configureKeycloakIdentityProviderPlugin(config).setAdministratorUserId(USER_ID_OPERATON_ADMIN);
+        configureKeycloakIdentityProviderPlugin(config).setAdministratorUserId(userIdOperatonAdmin);
         PluggableProcessEngineTestCase.cachedProcessEngine = config.buildProcessEngine();
       }
 

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameAndUseMailAsIdTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameAndUseMailAsIdTest.java
@@ -24,7 +24,7 @@ public class KeycloakConfigureAdminUserIdAsUsernameAndUseMailAsIdTest extends Ab
     return new TestSetup(new TestSuite(KeycloakConfigureAdminUserIdAsUsernameAndUseMailAsIdTest.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureAdminUserIdAsUsernameAndUseMailAsId.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config);
@@ -32,7 +32,7 @@ public class KeycloakConfigureAdminUserIdAsUsernameAndUseMailAsIdTest extends Ab
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameAndUseUsernameAsIdTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameAndUseUsernameAsIdTest.java
@@ -24,7 +24,7 @@ public class KeycloakConfigureAdminUserIdAsUsernameAndUseUsernameAsIdTest extend
     return new TestSetup(new TestSuite(KeycloakConfigureAdminUserIdAsUsernameAndUseUsernameAsIdTest.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureAdminUserIdAsUsernameAndUseUsernameAsId.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config);
@@ -32,7 +32,7 @@ public class KeycloakConfigureAdminUserIdAsUsernameAndUseUsernameAsIdTest extend
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameSimilarToClientName.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameSimilarToClientName.java
@@ -24,7 +24,7 @@ public class KeycloakConfigureAdminUserIdAsUsernameSimilarToClientName extends A
     return new TestSetup(new TestSuite(KeycloakConfigureAdminUserIdAsUsernameSimilarToClientName.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureAdminUserIdAsUsernameSimilarToClientName.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config);
@@ -32,7 +32,7 @@ public class KeycloakConfigureAdminUserIdAsUsernameSimilarToClientName extends A
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdAsUsernameTest.java
@@ -24,7 +24,7 @@ public class KeycloakConfigureAdminUserIdAsUsernameTest extends AbstractKeycloak
     return new TestSetup(new TestSuite(KeycloakConfigureAdminUserIdAsUsernameTest.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureAdminUserIdAsUsername.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config);
@@ -32,7 +32,7 @@ public class KeycloakConfigureAdminUserIdAsUsernameTest extends AbstractKeycloak
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdTest.java
@@ -24,7 +24,7 @@ public class KeycloakConfigureAdminUserIdTest extends AbstractKeycloakIdentityPr
     return new TestSetup(new TestSuite(KeycloakConfigureAdminUserIdTest.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureAdminUserId.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config).setAdministratorUserId(userIdOperatonAdmin);
@@ -32,7 +32,7 @@ public class KeycloakConfigureAdminUserIdTest extends AbstractKeycloakIdentityPr
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakConfigureAdminUserIdTest.java
@@ -27,7 +27,7 @@ public class KeycloakConfigureAdminUserIdTest extends AbstractKeycloakIdentityPr
       protected void setUp() throws Exception {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureAdminUserId.cfg.xml");
-        configureKeycloakIdentityProviderPlugin(config).setAdministratorUserId(USER_ID_OPERATON_ADMIN);
+        configureKeycloakIdentityProviderPlugin(config).setAdministratorUserId(userIdOperatonAdmin);
         PluggableProcessEngineTestCase.cachedProcessEngine = config.buildProcessEngine();
       }
 
@@ -58,7 +58,7 @@ public class KeycloakConfigureAdminUserIdTest extends AbstractKeycloakIdentityPr
     List<String> operatonAdminUsers = ((ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration()).getAdminUsers();
     assertEquals(1, operatonAdminUsers.size());
     String adminUserId = operatonAdminUsers.get(0);
-    assertEquals(USER_ID_OPERATON_ADMIN, adminUserId);
+    assertEquals(userIdOperatonAdmin, adminUserId);
 
     // check that authorizations have been created
     assertTrue(processEngine.getAuthorizationService().createAuthorizationQuery().userIdIn(adminUserId).count() > 0);

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTest.java
@@ -46,11 +46,11 @@ public class KeycloakGroupQueryTest extends AbstractKeycloakIdentityProviderTest
   }
 
   public void testFilterByGroupId() {
-    Group group = identityService.createGroupQuery().groupId(GROUP_ID_ADMIN).singleResult();
+    Group group = identityService.createGroupQuery().groupId(groupIdAdmin).singleResult();
     assertNotNull(group);
 
     // validate result
-    assertEquals(GROUP_ID_ADMIN, group.getId());
+    assertEquals(groupIdAdmin, group.getId());
     assertEquals("operaton-admin", group.getName());
     assertEquals("SYSTEM", group.getType());
 
@@ -87,18 +87,18 @@ public class KeycloakGroupQueryTest extends AbstractKeycloakIdentityProviderTest
   public void testFilterByGroupTypeAndGroupId() {
     Group group = identityService.createGroupQuery()
         .groupType("SYSTEM")
-        .groupId(GROUP_ID_SYSTEM_READONLY)
+        .groupId(groupIdSystemReadonly)
         .singleResult();
     assertNotNull(group);
 
     // validate result
-    assertEquals(GROUP_ID_SYSTEM_READONLY, group.getId());
+    assertEquals(groupIdSystemReadonly, group.getId());
     assertEquals("cam-read-only", group.getName());
     assertEquals("SYSTEM", group.getType());
   }
 
   public void testFilterByGroupIdIn() {
-    List<Group> groups = identityService.createGroupQuery().groupIdIn(GROUP_ID_ADMIN, GROUP_ID_MANAGER).list();
+    List<Group> groups = identityService.createGroupQuery().groupIdIn(groupIdAdmin, groupIdManager).list();
 
     assertEquals(2, groups.size());
     for (Group group : groups) {
@@ -107,11 +107,11 @@ public class KeycloakGroupQueryTest extends AbstractKeycloakIdentityProviderTest
       }
     }
 
-    groups = identityService.createGroupQuery().groupIdIn(GROUP_ID_MANAGER, "non-existent").list();
+    groups = identityService.createGroupQuery().groupIdIn(groupIdManager, "non-existent").list();
     assertEquals(1, groups.size());
     assertEquals("manager", groups.get(0).getName());
 
-    groups = identityService.createGroupQuery().groupIdIn(GROUP_ID_MANAGER).list();
+    groups = identityService.createGroupQuery().groupIdIn(groupIdManager).list();
     assertEquals(1, groups.size());
     assertEquals("manager", groups.get(0).getName());
 
@@ -119,14 +119,14 @@ public class KeycloakGroupQueryTest extends AbstractKeycloakIdentityProviderTest
 
   public void testFilterByGroupIdInAndType() {
     Group group = identityService.createGroupQuery()
-        .groupIdIn(GROUP_ID_ADMIN, GROUP_ID_MANAGER)
+        .groupIdIn(groupIdAdmin, groupIdManager)
         .groupType("WORKFLOW")
         .singleResult();
     assertNotNull(group);
     assertEquals("manager", group.getName());
 
     group = identityService.createGroupQuery()
-        .groupIdIn(GROUP_ID_ADMIN, GROUP_ID_MANAGER)
+        .groupIdIn(groupIdAdmin, groupIdManager)
         .groupType("SYSTEM")
         .singleResult();
     assertNotNull(group);
@@ -135,7 +135,7 @@ public class KeycloakGroupQueryTest extends AbstractKeycloakIdentityProviderTest
 
   public void testFilterByGroupIdInAndUserId() {
     Group group = identityService.createGroupQuery()
-        .groupIdIn(GROUP_ID_ADMIN, GROUP_ID_MANAGER)
+        .groupIdIn(groupIdAdmin, groupIdManager)
         .groupMember("operaton@accso.de")
         .singleResult();
     assertNotNull(group);
@@ -147,7 +147,7 @@ public class KeycloakGroupQueryTest extends AbstractKeycloakIdentityProviderTest
     assertNotNull(group);
 
     // validate result
-    assertEquals(GROUP_ID_MANAGER, group.getId());
+    assertEquals(groupIdManager, group.getId());
     assertEquals("manager", group.getName());
 
     group = identityService.createGroupQuery().groupName("whatever").singleResult();
@@ -159,7 +159,7 @@ public class KeycloakGroupQueryTest extends AbstractKeycloakIdentityProviderTest
     assertNotNull(group);
 
     // validate result
-    assertEquals(GROUP_ID_MANAGER, group.getId());
+    assertEquals(groupIdManager, group.getId());
     assertEquals("manager", group.getName());
 
     group = identityService.createGroupQuery().groupNameLike("what*").singleResult();
@@ -171,7 +171,7 @@ public class KeycloakGroupQueryTest extends AbstractKeycloakIdentityProviderTest
     assertNotNull(group);
 
     // validate result
-    assertEquals(GROUP_ID_MANAGER, group.getId());
+    assertEquals(groupIdManager, group.getId());
     assertEquals("manager", group.getName());
   }
 

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTestWithCaching.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTestWithCaching.java
@@ -21,7 +21,7 @@ public class KeycloakGroupQueryTestWithCaching extends AbstractKeycloakIdentityP
     return new TestSetup(new TestSuite(KeycloakUserQueryTestWithCaching.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.enableCaching.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config);
@@ -29,7 +29,7 @@ public class KeycloakGroupQueryTestWithCaching extends AbstractKeycloakIdentityP
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTestWithCaching.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakGroupQueryTestWithCaching.java
@@ -82,11 +82,11 @@ public class KeycloakGroupQueryTestWithCaching extends AbstractKeycloakIdentityP
   public void testCacheEnabledQueryFilterByGroupId() {
     int countBefore = CountingHttpRequestInterceptor.getHttpRequestCount();
 
-    Group group = identityService.createGroupQuery().groupId(GROUP_ID_ADMIN).singleResult();
+    Group group = identityService.createGroupQuery().groupId(groupIdAdmin).singleResult();
     assertNotNull(group);
 
     // validate result
-    assertEquals(GROUP_ID_ADMIN, group.getId());
+    assertEquals(groupIdAdmin, group.getId());
     assertEquals("operaton-admin", group.getName());
     assertEquals("SYSTEM", group.getType());
 
@@ -94,7 +94,7 @@ public class KeycloakGroupQueryTestWithCaching extends AbstractKeycloakIdentityP
     assertEquals(countBefore + 1, CountingHttpRequestInterceptor.getHttpRequestCount());
 
     // run query again
-    assertEquals(group, identityService.createGroupQuery().groupId(GROUP_ID_ADMIN).singleResult());
+    assertEquals(group, identityService.createGroupQuery().groupId(groupIdAdmin).singleResult());
 
     // request count should be same as before
     assertEquals(countBefore + 1, CountingHttpRequestInterceptor.getHttpRequestCount());

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakMassDataTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakMassDataTest.java
@@ -43,7 +43,7 @@ public class KeycloakMassDataTest extends AbstractKeycloakIdentityProviderTest {
                   "test"));
         }
         HttpHeaders finalHeaders = headers;
-        USER_IDS.forEach(u -> assignUserGroup(finalHeaders, realm, u, GROUP_ID_MANAGER));
+        USER_IDS.forEach(u -> assignUserGroup(finalHeaders, realm, u, groupIdManager));
 
         headers = authenticateKeycloakAdmin();
         for (int i = 0; i < 60; i++) {
@@ -54,13 +54,13 @@ public class KeycloakMassDataTest extends AbstractKeycloakIdentityProviderTest {
           GROUP_IDS.add(createGroup(headers, realm, "group.test" + i, false));
         }
         HttpHeaders finalHeaders1 = headers;
-        GROUP_IDS.forEach(g -> assignUserGroup(finalHeaders1, realm, USER_ID_TEAMLEAD, g));
+        GROUP_IDS.forEach(g -> assignUserGroup(finalHeaders1, realm, userIdTeamlead, g));
 
         // setup process engine
         // -------------------------------------
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureHigherMaxResultSize.cfg.xml");
-        configureKeycloakIdentityProviderPlugin(config).setAdministratorUserId(USER_ID_OPERATON_ADMIN);
+        configureKeycloakIdentityProviderPlugin(config).setAdministratorUserId(userIdOperatonAdmin);
         PluggableProcessEngineTestCase.cachedProcessEngine = config.buildProcessEngine();
       }
 
@@ -90,7 +90,7 @@ public class KeycloakMassDataTest extends AbstractKeycloakIdentityProviderTest {
   }
 
   public void testGroupMemberQuery() {
-    List<User> result = identityService.createUserQuery().memberOfGroup(GROUP_ID_MANAGER).list();
+    List<User> result = identityService.createUserQuery().memberOfGroup(groupIdManager).list();
     assertEquals(USER_IDS.size() + 1, result.size());
   }
 

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakMassDataTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakMassDataTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import junit.extensions.TestSetup;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.json.JSONException;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.identity.Group;
 import org.operaton.bpm.engine.identity.User;
@@ -26,7 +27,7 @@ public class KeycloakMassDataTest extends AbstractKeycloakIdentityProviderTest {
     return new TestSetup(new TestSuite(KeycloakMassDataTest.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() throws JSONException {
         // setup Keycloak mass data test users
         // -------------------------------------
         HttpHeaders headers = authenticateKeycloakAdmin();
@@ -65,7 +66,7 @@ public class KeycloakMassDataTest extends AbstractKeycloakIdentityProviderTest {
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() throws JSONException {
         // tear down process engine
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakMaxResultSizeTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakMaxResultSizeTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import junit.extensions.TestSetup;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.json.JSONException;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.identity.Group;
 import org.operaton.bpm.engine.identity.User;
@@ -25,7 +26,7 @@ public class KeycloakMaxResultSizeTest extends AbstractKeycloakIdentityProviderT
     return new TestSetup(new TestSuite(KeycloakMaxResultSizeTest.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() throws JSONException {
         // setup Keycloak mass data test users
         // -------------------------------------
         HttpHeaders headers = authenticateKeycloakAdmin();
@@ -51,7 +52,7 @@ public class KeycloakMaxResultSizeTest extends AbstractKeycloakIdentityProviderT
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() throws JSONException {
         // tear down process engine
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakMaxResultSizeTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakMaxResultSizeTest.java
@@ -35,18 +35,18 @@ public class KeycloakMaxResultSizeTest extends AbstractKeycloakIdentityProviderT
               createUser(headers, realm, "user.test" + i, "UTest" + i, "User Test" + i, "utest.user" + i + "@test.info",
                   "test"));
         }
-        USER_IDS.forEach(u -> assignUserGroup(headers, realm, u, GROUP_ID_MANAGER));
+        USER_IDS.forEach(u -> assignUserGroup(headers, realm, u, groupIdManager));
 
         for (int i = 0; i < 50; i++) {
           GROUP_IDS.add(createGroup(headers, realm, "group.test" + i, false));
         }
-        GROUP_IDS.forEach(g -> assignUserGroup(headers, realm, USER_ID_TEAMLEAD, g));
+        GROUP_IDS.forEach(g -> assignUserGroup(headers, realm, userIdTeamlead, g));
 
         // setup process engine
         // -------------------------------------
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.configureSmallMaxResultSize.cfg.xml");
-        configureKeycloakIdentityProviderPlugin(config).setAdministratorUserId(USER_ID_OPERATON_ADMIN);
+        configureKeycloakIdentityProviderPlugin(config).setAdministratorUserId(userIdOperatonAdmin);
         PluggableProcessEngineTestCase.cachedProcessEngine = config.buildProcessEngine();
       }
 
@@ -76,7 +76,7 @@ public class KeycloakMaxResultSizeTest extends AbstractKeycloakIdentityProviderT
   }
 
   public void testGroupMemberQuery() {
-    List<User> result = identityService.createUserQuery().memberOfGroup(GROUP_ID_MANAGER).list();
+    List<User> result = identityService.createUserQuery().memberOfGroup(groupIdManager).list();
     assertEquals(25, result.size());
   }
 

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakNestedGroupsQueryTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakNestedGroupsQueryTest.java
@@ -11,23 +11,23 @@ import org.operaton.bpm.engine.identity.User;
 public class KeycloakNestedGroupsQueryTest extends AbstractKeycloakIdentityProviderTest {
 
   public void testGroupQueryFilterByGroupIdRoot() {
-    Group group = identityService.createGroupQuery().groupId(GROUP_ID_HIERARCHY_ROOT).singleResult();
+    Group group = identityService.createGroupQuery().groupId(groupIdHierarchyRoot).singleResult();
     assertNotNull(group);
-    assertEquals(GROUP_ID_HIERARCHY_ROOT, group.getId());
+    assertEquals(groupIdHierarchyRoot, group.getId());
     assertEquals("root", group.getName());
   }
 
   public void testGroupQueryFilterByGroupIdChild() {
-    Group group = identityService.createGroupQuery().groupId(GROUP_ID_HIERARCHY_CHILD1).singleResult();
+    Group group = identityService.createGroupQuery().groupId(groupIdHierarchyChild1).singleResult();
     assertNotNull(group);
-    assertEquals(GROUP_ID_HIERARCHY_CHILD1, group.getId());
+    assertEquals(groupIdHierarchyChild1, group.getId());
     assertEquals("child1", group.getName());
   }
 
   public void testGroupQueryFilterByGroupIdSubChild() {
-    Group group = identityService.createGroupQuery().groupId(GROUP_ID_HIERARCHY_SUBCHILD1).singleResult();
+    Group group = identityService.createGroupQuery().groupId(groupIdHierarchySubchild1).singleResult();
     assertNotNull(group);
-    assertEquals(GROUP_ID_HIERARCHY_SUBCHILD1, group.getId());
+    assertEquals(groupIdHierarchySubchild1, group.getId());
     assertEquals("subchild1", group.getName());
   }
 
@@ -41,7 +41,7 @@ public class KeycloakNestedGroupsQueryTest extends AbstractKeycloakIdentityProvi
   }
 
   public void testGroupQueryFilterByGroupIdIn() {
-    List<Group> groups = identityService.createGroupQuery().groupIdIn(GROUP_ID_ADMIN, GROUP_ID_HIERARCHY_CHILD1).list();
+    List<Group> groups = identityService.createGroupQuery().groupIdIn(groupIdAdmin, groupIdHierarchyChild1).list();
     assertEquals(2, groups.size());
     assertEquals("operaton-admin not found", 1,
         groups.stream().filter(g -> "operaton-admin".equals(g.getName())).count());
@@ -50,7 +50,7 @@ public class KeycloakNestedGroupsQueryTest extends AbstractKeycloakIdentityProvi
 
   public void testGroupQueryFilterByGroupIdInAndUserId() {
     Group group = identityService.createGroupQuery()
-        .groupIdIn(GROUP_ID_ADMIN, GROUP_ID_MANAGER, GROUP_ID_HIERARCHY_CHILD2, GROUP_ID_HIERARCHY_CHILD1)
+        .groupIdIn(groupIdAdmin, groupIdManager, groupIdHierarchyChild2, groupIdHierarchyChild1)
         .groupMember("johnfoo@gmail.com")
         .singleResult();
     assertNotNull(group);
@@ -60,7 +60,7 @@ public class KeycloakNestedGroupsQueryTest extends AbstractKeycloakIdentityProvi
   public void testGroupQueryFilterByGroupName() {
     Group group = identityService.createGroupQuery().groupName("child1").singleResult();
     assertNotNull(group);
-    assertEquals(GROUP_ID_HIERARCHY_CHILD1, group.getId());
+    assertEquals(groupIdHierarchyChild1, group.getId());
     assertEquals("child1", group.getName());
   }
 
@@ -85,7 +85,7 @@ public class KeycloakNestedGroupsQueryTest extends AbstractKeycloakIdentityProvi
   public void testGroupQueryFilterByGroupNameAndGroupNameLike() {
     Group group = identityService.createGroupQuery().groupNameLike("child*").groupName("child2").singleResult();
     assertNotNull(group);
-    assertEquals(GROUP_ID_HIERARCHY_CHILD2, group.getId());
+    assertEquals(groupIdHierarchyChild2, group.getId());
     assertEquals("child2", group.getName());
   }
 
@@ -99,15 +99,15 @@ public class KeycloakNestedGroupsQueryTest extends AbstractKeycloakIdentityProvi
   }
 
   public void testUserQueryFilterByMemberOfGroup() {
-    User user = identityService.createUserQuery().memberOfGroup(GROUP_ID_HIERARCHY_SUBCHILD1).singleResult();
+    User user = identityService.createUserQuery().memberOfGroup(groupIdHierarchySubchild1).singleResult();
     assertNotNull(user);
     assertEquals("johnfoo@gmail.com", user.getId());
 
-    user = identityService.createUserQuery().memberOfGroup(GROUP_ID_HIERARCHY_CHILD2).singleResult();
+    user = identityService.createUserQuery().memberOfGroup(groupIdHierarchyChild2).singleResult();
     assertNotNull(user);
     assertEquals("johnfoo@gmail.com", user.getId());
 
-    user = identityService.createUserQuery().memberOfGroup(GROUP_ID_HIERARCHY_CHILD1).singleResult();
+    user = identityService.createUserQuery().memberOfGroup(groupIdHierarchyChild1).singleResult();
     assertNull(user);
   }
 

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUseGroupPathdAsGroupIdQueryTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUseGroupPathdAsGroupIdQueryTest.java
@@ -21,7 +21,7 @@ public class KeycloakUseGroupPathdAsGroupIdQueryTest extends AbstractKeycloakIde
     return new TestSetup(new TestSuite(KeycloakUseGroupPathdAsGroupIdQueryTest.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.useGroupPathAsOperatonGroupId.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config);
@@ -29,7 +29,7 @@ public class KeycloakUseGroupPathdAsGroupIdQueryTest extends AbstractKeycloakIde
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUseKeycloakIdAsUserIdQueryTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUseKeycloakIdAsUserIdQueryTest.java
@@ -41,7 +41,7 @@ public class KeycloakUseKeycloakIdAsUserIdQueryTest extends AbstractKeycloakIden
   // ------------------------------------------------------------------------
 
   public void testKeycloakLoginSuccess() {
-    assertTrue(identityService.checkPassword(USER_ID_OPERATON_ADMIN, "operaton1!"));
+    assertTrue(identityService.checkPassword(userIdOperatonAdmin, "operaton1!"));
   }
 
   // ------------------------------------------------------------------------
@@ -49,14 +49,14 @@ public class KeycloakUseKeycloakIdAsUserIdQueryTest extends AbstractKeycloakIden
   // ------------------------------------------------------------------------
 
   public void testUserQueryFilterByUserId() {
-    User user = identityService.createUserQuery().userId(USER_ID_TEAMLEAD).singleResult();
+    User user = identityService.createUserQuery().userId(userIdTeamlead).singleResult();
     assertNotNull(user);
 
-    user = identityService.createUserQuery().userId(USER_ID_OPERATON_ADMIN).singleResult();
+    user = identityService.createUserQuery().userId(userIdOperatonAdmin).singleResult();
     assertNotNull(user);
 
     // validate user
-    assertEquals(USER_ID_OPERATON_ADMIN, user.getId());
+    assertEquals(userIdOperatonAdmin, user.getId());
     assertEquals("Admin", user.getFirstName());
     assertEquals("Operaton", user.getLastName());
     assertEquals("operaton@accso.de", user.getEmail());
@@ -66,11 +66,11 @@ public class KeycloakUseKeycloakIdAsUserIdQueryTest extends AbstractKeycloakIden
   }
 
   public void testUserQueryFilterByUserIdIn() {
-    List<User> users = identityService.createUserQuery().userIdIn(USER_ID_OPERATON_ADMIN, USER_ID_TEAMLEAD).list();
+    List<User> users = identityService.createUserQuery().userIdIn(userIdOperatonAdmin, userIdTeamlead).list();
     assertNotNull(users);
     assertEquals(2, users.size());
 
-    users = identityService.createUserQuery().userIdIn(USER_ID_OPERATON_ADMIN, "non-existing").list();
+    users = identityService.createUserQuery().userIdIn(userIdOperatonAdmin, "non-existing").list();
     assertNotNull(users);
     assertEquals(1, users.size());
   }
@@ -80,7 +80,7 @@ public class KeycloakUseKeycloakIdAsUserIdQueryTest extends AbstractKeycloakIden
     assertNotNull(user);
 
     // validate user
-    assertEquals(USER_ID_OPERATON_ADMIN, user.getId());
+    assertEquals(userIdOperatonAdmin, user.getId());
     assertEquals("Admin", user.getFirstName());
     assertEquals("Operaton", user.getLastName());
     assertEquals("operaton@accso.de", user.getEmail());
@@ -91,15 +91,15 @@ public class KeycloakUseKeycloakIdAsUserIdQueryTest extends AbstractKeycloakIden
 
   public void testUserQueryFilterByGroupIdAndId() {
     List<User> result = identityService.createUserQuery()
-        .memberOfGroup(GROUP_ID_ADMIN)
-        .userId(USER_ID_OPERATON_ADMIN)
+        .memberOfGroup(groupIdAdmin)
+        .userId(userIdOperatonAdmin)
         .list();
     assertEquals(1, result.size());
 
-    result = identityService.createUserQuery().memberOfGroup(GROUP_ID_ADMIN).userId("non-exist").list();
+    result = identityService.createUserQuery().memberOfGroup(groupIdAdmin).userId("non-exist").list();
     assertEquals(0, result.size());
 
-    result = identityService.createUserQuery().memberOfGroup("non-exist").userId(USER_ID_OPERATON_ADMIN).list();
+    result = identityService.createUserQuery().memberOfGroup("non-exist").userId(userIdOperatonAdmin).list();
     assertEquals(0, result.size());
 
   }
@@ -111,7 +111,7 @@ public class KeycloakUseKeycloakIdAsUserIdQueryTest extends AbstractKeycloakIden
       identityService.setAuthenticatedUserId("non-existing");
       assertEquals(0, identityService.createUserQuery().count());
 
-      identityService.setAuthenticatedUserId(USER_ID_OPERATON_ADMIN);
+      identityService.setAuthenticatedUserId(userIdOperatonAdmin);
       assertEquals(1, identityService.createUserQuery().count());
 
     } finally {
@@ -125,7 +125,7 @@ public class KeycloakUseKeycloakIdAsUserIdQueryTest extends AbstractKeycloakIden
   // ------------------------------------------------------------------------
 
   public void testGroupQueryFilterByUserId() {
-    List<Group> result = identityService.createGroupQuery().groupMember(USER_ID_OPERATON_ADMIN).list();
+    List<Group> result = identityService.createGroupQuery().groupMember(userIdOperatonAdmin).list();
     assertEquals(1, result.size());
 
     result = identityService.createGroupQuery().groupMember("non-exist").list();
@@ -134,29 +134,29 @@ public class KeycloakUseKeycloakIdAsUserIdQueryTest extends AbstractKeycloakIden
 
   public void testFilterByGroupIdAndUserId() {
     Group group = identityService.createGroupQuery()
-        .groupId(GROUP_ID_ADMIN)
-        .groupMember(USER_ID_OPERATON_ADMIN)
+        .groupId(groupIdAdmin)
+        .groupMember(userIdOperatonAdmin)
         .singleResult();
     assertNotNull(group);
     assertEquals("operaton-admin", group.getName());
 
-    group = identityService.createGroupQuery().groupId("non-exist").groupMember(USER_ID_OPERATON_ADMIN).singleResult();
+    group = identityService.createGroupQuery().groupId("non-exist").groupMember(userIdOperatonAdmin).singleResult();
     assertNull(group);
 
-    group = identityService.createGroupQuery().groupId(GROUP_ID_ADMIN).groupMember("non-exist").singleResult();
+    group = identityService.createGroupQuery().groupId(groupIdAdmin).groupMember("non-exist").singleResult();
     assertNull(group);
   }
 
   public void testFilterByGroupIdInAndUserId() {
     Group group = identityService.createGroupQuery()
-        .groupIdIn(GROUP_ID_ADMIN, GROUP_ID_TEAMLEAD)
-        .groupMember(USER_ID_OPERATON_ADMIN)
+        .groupIdIn(groupIdAdmin, groupIdTeamlead)
+        .groupMember(userIdOperatonAdmin)
         .singleResult();
     assertNotNull(group);
     assertEquals("operaton-admin", group.getName());
 
     group = identityService.createGroupQuery()
-        .groupIdIn(GROUP_ID_ADMIN, GROUP_ID_TEAMLEAD)
+        .groupIdIn(groupIdAdmin, groupIdTeamlead)
         .groupMember("non-exist")
         .singleResult();
     assertNull(group);

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUseKeycloakIdAsUserIdQueryTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUseKeycloakIdAsUserIdQueryTest.java
@@ -21,7 +21,7 @@ public class KeycloakUseKeycloakIdAsUserIdQueryTest extends AbstractKeycloakIden
     return new TestSetup(new TestSuite(KeycloakUseKeycloakIdAsUserIdQueryTest.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.useKeycloakIdAsOperatonUserId.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config);
@@ -29,7 +29,7 @@ public class KeycloakUseKeycloakIdAsUserIdQueryTest extends AbstractKeycloakIden
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUseUsernameAsUserIdQueryTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUseUsernameAsUserIdQueryTest.java
@@ -121,10 +121,10 @@ public class KeycloakUseUsernameAsUserIdQueryTest extends AbstractKeycloakIdenti
   }
 
   public void testUserQueryFilterByGroupIdAndId() {
-    List<User> result = identityService.createUserQuery().memberOfGroup(GROUP_ID_ADMIN).userId("operaton").list();
+    List<User> result = identityService.createUserQuery().memberOfGroup(groupIdAdmin).userId("operaton").list();
     assertEquals(1, result.size());
 
-    result = identityService.createUserQuery().memberOfGroup(GROUP_ID_ADMIN).userId("non-exist").list();
+    result = identityService.createUserQuery().memberOfGroup(groupIdAdmin).userId("non-exist").list();
     assertEquals(0, result.size());
 
     result = identityService.createUserQuery().memberOfGroup("non-exist").userId("operaton").list();
@@ -161,27 +161,27 @@ public class KeycloakUseUsernameAsUserIdQueryTest extends AbstractKeycloakIdenti
   }
 
   public void testFilterByGroupIdAndUserId() {
-    Group group = identityService.createGroupQuery().groupId(GROUP_ID_ADMIN).groupMember("operaton").singleResult();
+    Group group = identityService.createGroupQuery().groupId(groupIdAdmin).groupMember("operaton").singleResult();
     assertNotNull(group);
     assertEquals("operaton-admin", group.getName());
 
     group = identityService.createGroupQuery().groupId("non-exist").groupMember("operaton").singleResult();
     assertNull(group);
 
-    group = identityService.createGroupQuery().groupId(GROUP_ID_ADMIN).groupMember("non-exist").singleResult();
+    group = identityService.createGroupQuery().groupId(groupIdAdmin).groupMember("non-exist").singleResult();
     assertNull(group);
   }
 
   public void testFilterByGroupIdInAndUserId() {
     Group group = identityService.createGroupQuery()
-        .groupIdIn(GROUP_ID_ADMIN, GROUP_ID_TEAMLEAD)
+        .groupIdIn(groupIdAdmin, groupIdTeamlead)
         .groupMember("operaton")
         .singleResult();
     assertNotNull(group);
     assertEquals("operaton-admin", group.getName());
 
     group = identityService.createGroupQuery()
-        .groupIdIn(GROUP_ID_ADMIN, GROUP_ID_TEAMLEAD)
+        .groupIdIn(groupIdAdmin, groupIdTeamlead)
         .groupMember("non-exist")
         .singleResult();
     assertNull(group);
@@ -190,7 +190,7 @@ public class KeycloakUseUsernameAsUserIdQueryTest extends AbstractKeycloakIdenti
   public void testGroupQueryFilterByUserIdSimilarToClientName() {
     Group group = identityService.createGroupQuery().groupMember("operaton-identity-service").singleResult();
     assertNotNull(group);
-    assertEquals(GROUP_ID_SIMILAR_CLIENT_NAME, group.getId());
+    assertEquals(groupIdSimilarClientName, group.getId());
     assertEquals("operaton-identity-service", group.getName());
   }
 }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUseUsernameAsUserIdQueryTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUseUsernameAsUserIdQueryTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import junit.extensions.TestSetup;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.json.JSONException;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.identity.Group;
 import org.operaton.bpm.engine.identity.User;
@@ -25,7 +26,7 @@ public class KeycloakUseUsernameAsUserIdQueryTest extends AbstractKeycloakIdenti
     return new TestSetup(new TestSuite(KeycloakUseUsernameAsUserIdQueryTest.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() throws JSONException {
         // setup Keycloak special test users
         // -------------------------------------
         HttpHeaders headers = authenticateKeycloakAdmin();
@@ -39,7 +40,7 @@ public class KeycloakUseUsernameAsUserIdQueryTest extends AbstractKeycloakIdenti
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() throws JSONException {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
 

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTest.java
@@ -163,7 +163,7 @@ public class KeycloakUserQueryTest extends AbstractKeycloakIdentityProviderTest 
   }
 
   public void testFilterByGroupId() {
-    List<User> result = identityService.createUserQuery().memberOfGroup(GROUP_ID_TEAMLEAD).list();
+    List<User> result = identityService.createUserQuery().memberOfGroup(groupIdTeamlead).list();
     assertEquals(2, result.size());
 
     result = identityService.createUserQuery().memberOfGroup("non-exist").list();
@@ -172,7 +172,7 @@ public class KeycloakUserQueryTest extends AbstractKeycloakIdentityProviderTest 
 
   public void testFilterByGroupIdAndFirstname() {
     List<User> result = identityService.createUserQuery()
-        .memberOfGroup(GROUP_ID_TEAMLEAD)
+        .memberOfGroup(groupIdTeamlead)
         .userFirstName("Gunnar")
         .list();
     assertEquals(1, result.size());
@@ -180,7 +180,7 @@ public class KeycloakUserQueryTest extends AbstractKeycloakIdentityProviderTest 
 
   public void testFilterByGroupIdAndId() {
     List<User> result = identityService.createUserQuery()
-        .memberOfGroup(GROUP_ID_TEAMLEAD)
+        .memberOfGroup(groupIdTeamlead)
         .userId("gunnar.von-der-beck@accso.de")
         .list();
     assertEquals(1, result.size());
@@ -188,7 +188,7 @@ public class KeycloakUserQueryTest extends AbstractKeycloakIdentityProviderTest 
 
   public void testFilterByGroupIdAndLastname() {
     List<User> result = identityService.createUserQuery()
-        .memberOfGroup(GROUP_ID_TEAMLEAD)
+        .memberOfGroup(groupIdTeamlead)
         .userLastName("von der Beck")
         .list();
     assertEquals(1, result.size());
@@ -196,7 +196,7 @@ public class KeycloakUserQueryTest extends AbstractKeycloakIdentityProviderTest 
 
   public void testFilterByGroupIdAndEmail() {
     List<User> result = identityService.createUserQuery()
-        .memberOfGroup(GROUP_ID_TEAMLEAD)
+        .memberOfGroup(groupIdTeamlead)
         .userEmail("gunnar.von-der-beck@accso.de")
         .list();
     assertEquals(1, result.size());
@@ -204,7 +204,7 @@ public class KeycloakUserQueryTest extends AbstractKeycloakIdentityProviderTest 
 
   public void testFilterByGroupIdAndEmailLike() {
     List<User> result = identityService.createUserQuery()
-        .memberOfGroup(GROUP_ID_TEAMLEAD)
+        .memberOfGroup(groupIdTeamlead)
         .userEmailLike("*@accso.de")
         .list();
     assertEquals(1, result.size());

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTest.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTest.java
@@ -140,7 +140,7 @@ public class KeycloakUserQueryTest extends AbstractKeycloakIdentityProviderTest 
     assertNotNull(user);
   }
 
-  public void testFilterByEmail() throws Exception {
+  public void testFilterByEmail() {
     User user = identityService.createUserQuery().userEmail("operaton@accso.de").singleResult();
     assertNotNull(user);
 
@@ -148,7 +148,7 @@ public class KeycloakUserQueryTest extends AbstractKeycloakIdentityProviderTest 
     assertNull(user);
   }
 
-  public void testFilterByEmailLike() throws Exception {
+  public void testFilterByEmailLike() {
     User user = identityService.createUserQuery().userEmailLike("operaton@*").singleResult();
     assertNotNull(user);
     user = identityService.createUserQuery().userEmailLike("operaton@%").singleResult();

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTestWithCaching.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTestWithCaching.java
@@ -21,7 +21,7 @@ public class KeycloakUserQueryTestWithCaching extends AbstractKeycloakIdentityPr
     return new TestSetup(new TestSuite(KeycloakUserQueryTestWithCaching.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.enableCaching.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config);
@@ -29,7 +29,7 @@ public class KeycloakUserQueryTestWithCaching extends AbstractKeycloakIdentityPr
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTestWithCachingAndCustomCacheExpiry.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTestWithCachingAndCustomCacheExpiry.java
@@ -28,7 +28,7 @@ public class KeycloakUserQueryTestWithCachingAndCustomCacheExpiry extends Abstra
     return new TestSetup(new TestSuite(KeycloakUserQueryTestWithCachingAndCustomCacheExpiry.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.enableCachingAndConfigureCacheDuration.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config);
@@ -36,7 +36,7 @@ public class KeycloakUserQueryTestWithCachingAndCustomCacheExpiry extends Abstra
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }

--- a/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTestWithCachingAndMaxSize.java
+++ b/extension/src/test/java/org/operaton/bpm/extension/keycloak/test/KeycloakUserQueryTestWithCachingAndMaxSize.java
@@ -28,7 +28,7 @@ public class KeycloakUserQueryTestWithCachingAndMaxSize extends AbstractKeycloak
     return new TestSetup(new TestSuite(KeycloakUserQueryTestWithCachingAndMaxSize.class)) {
 
       // @BeforeClass
-      protected void setUp() throws Exception {
+      protected void setUp() {
         ProcessEngineConfigurationImpl config = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource(
             "operaton.enableCachingAndConfigureMaxCacheSize.cfg.xml");
         configureKeycloakIdentityProviderPlugin(config);
@@ -36,7 +36,7 @@ public class KeycloakUserQueryTestWithCachingAndMaxSize extends AbstractKeycloak
       }
 
       // @AfterClass
-      protected void tearDown() throws Exception {
+      protected void tearDown() {
         PluggableProcessEngineTestCase.cachedProcessEngine.close();
         PluggableProcessEngineTestCase.cachedProcessEngine = null;
       }


### PR DESCRIPTION
Cleanups:
- renamed non-static final fields in AbstractKeycloakIdentityProviderTest
- removed unnecessary throws declarations