### PR TITLE
chore: Update to Operaton 1.0.0-beta-4-SNAPSHOT

### DIFF
--- a/extension-jwt/pom.xml
+++ b/extension-jwt/pom.xml
@@ -44,10 +44,9 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.operaton.bpm.webapp</groupId>
-      <artifactId>operaton-webapp-jakarta</artifactId>
+      <artifactId>operaton-webapp</artifactId>
       <classifier>classes</classifier>
       <scope>provided</scope>
     </dependency>
@@ -57,6 +56,7 @@
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
+
   </dependencies>
 
   <build>

--- a/extension-jwt/src/test/java/org/operaton/bpm/extension/keycloak/filter/StatelessAuthenticationFilterTest.java
+++ b/extension-jwt/src/test/java/org/operaton/bpm/extension/keycloak/filter/StatelessAuthenticationFilterTest.java
@@ -1,6 +1,18 @@
 package org.operaton.bpm.extension.keycloak.filter;
 
-import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.operaton.bpm.cockpit.Cockpit;
+import org.operaton.bpm.cockpit.impl.DefaultCockpitRuntimeDelegate;
+import org.operaton.bpm.engine.IdentityService;
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.impl.identity.Authentication;
+import org.operaton.bpm.engine.rest.security.auth.AuthenticationProvider;
+import org.operaton.bpm.engine.rest.security.auth.AuthenticationResult;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.extension.keycloak.auth.KeycloakJwtAuthenticationFilter;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -8,111 +20,106 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
-import org.operaton.bpm.cockpit.Cockpit;
-import org.operaton.bpm.cockpit.impl.DefaultCockpitRuntimeDelegate;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.impl.identity.Authentication;
-import org.operaton.bpm.engine.impl.test.PluggableProcessEngineTestCase;
-import org.operaton.bpm.engine.rest.security.auth.AuthenticationProvider;
-import org.operaton.bpm.engine.rest.security.auth.AuthenticationResult;
-import org.operaton.bpm.extension.keycloak.auth.KeycloakJwtAuthenticationFilter;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
-public class StatelessAuthenticationFilterTest extends PluggableProcessEngineTestCase {
+@ExtendWith(ProcessEngineExtension.class)
+class StatelessAuthenticationFilterTest {
 
-  private final AuthenticationProvider authenticationProvider = mock(AuthenticationProvider.class);
+    private final AuthenticationProvider authenticationProvider = mock(AuthenticationProvider.class);
 
-  private final KeycloakJwtAuthenticationFilter statelessAuthenticationFilter = new KeycloakJwtAuthenticationFilter(
-      "") {
-    {
-      authenticationProvider = StatelessAuthenticationFilterTest.this.authenticationProvider;
+    ProcessEngine processEngine;
+
+    private final KeycloakJwtAuthenticationFilter statelessAuthenticationFilter = new KeycloakJwtAuthenticationFilter("") {
+        {
+            authenticationProvider = StatelessAuthenticationFilterTest.this.authenticationProvider;
+        }
+    };
+
+    @BeforeEach
+    void setUp() {
+        Cockpit.setCockpitRuntimeDelegate(new DefaultCockpitRuntimeDelegate());
+        IdentityService identityService = processEngine.getIdentityService();
+        identityService.saveUser(identityService.newUser("user"));
     }
-  };
+    
+    @AfterEach
+    void tearDown() {
+        processEngine.getIdentityService().deleteUser("user");
+    }
 
-  @Override
-  protected void setUp() {
-    Cockpit.setCockpitRuntimeDelegate(new DefaultCockpitRuntimeDelegate());
-    IdentityService identityService = getProcessEngine().getIdentityService();
-    identityService.saveUser(identityService.newUser("user"));
-  }
+    @Test
+    void testDoFilterForProtectedResource() throws ServletException, IOException {
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+        HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
 
-  @Override
-  protected void tearDown() {
-    getProcessEngine().getIdentityService().deleteUser("user");
-  }
+        when(httpServletRequest.getRequestURI()).thenReturn("/api/test");
+        when(httpServletRequest.getMethod()).thenReturn("GET");
 
-  public void testDoFilterForProtectedResource() throws ServletException, IOException {
-    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
-    HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+        when(authenticationProvider.extractAuthenticatedUser(any(), any()))
+                .thenReturn(new AuthenticationResult("user", true));
 
-    when(httpServletRequest.getRequestURI()).thenReturn("/api/test");
-    when(httpServletRequest.getMethod()).thenReturn("GET");
-
-    when(authenticationProvider.extractAuthenticatedUser(any(), any())).thenReturn(
-        new AuthenticationResult("user", true));
-
-    FilterChain filterChain = spy(new FilterChain() {
-      @Override
-      public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse) {
-        Authentication currentAuthentication = processEngine.getIdentityService().getCurrentAuthentication();
-        assertNotNull(currentAuthentication);
-        assertEquals("user", currentAuthentication.getUserId());
-      }
-    });
-
-    statelessAuthenticationFilter.doFilter(httpServletRequest, httpServletResponse, filterChain);
-    verify(filterChain).doFilter(httpServletRequest, httpServletResponse);
-
-    Authentication currentAuthentication = processEngine.getIdentityService().getCurrentAuthentication();
-    assertNull(currentAuthentication);
-  }
-
-  public void testDoFilterForStaticResource() throws ServletException, IOException {
-    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
-    HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
-
-    when(httpServletRequest.getRequestURI()).thenReturn("/api/cockpit/plugin/test/static/test");
-    when(httpServletRequest.getMethod()).thenReturn("GET");
-
-    when(authenticationProvider.extractAuthenticatedUser(any(), any())).thenReturn(
-        new AuthenticationResult("user", true));
-
-    statelessAuthenticationFilter.doFilter(httpServletRequest, httpServletResponse,
-        (servletRequest, servletResponse) -> {
-          Authentication currentAuthentication = processEngine.getIdentityService().getCurrentAuthentication();
-          assertNull(currentAuthentication);
+        FilterChain filterChain = spy(new FilterChain() {
+            @Override
+            public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse) {
+                Authentication currentAuthentication = processEngine.getIdentityService().getCurrentAuthentication();
+                assertNotNull(currentAuthentication);
+                assertEquals("user", currentAuthentication.getUserId());
+            }
         });
 
-    Authentication currentAuthentication = processEngine.getIdentityService().getCurrentAuthentication();
-    assertNull(currentAuthentication);
-  }
+        statelessAuthenticationFilter.doFilter(httpServletRequest, httpServletResponse, filterChain);
+        verify(filterChain).doFilter(httpServletRequest, httpServletResponse);
 
-  public void testDoFilterForProtectedResourceWithoutUser() throws ServletException, IOException {
-    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
-    HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+        Authentication currentAuthentication = processEngine.getIdentityService().getCurrentAuthentication();
+        assertNull(currentAuthentication);
+    }
 
-    when(httpServletRequest.getRequestURI()).thenReturn("/api/test");
-    when(httpServletRequest.getMethod()).thenReturn("GET");
+    @Test
+    void testDoFilterForStaticResource() throws ServletException, IOException {
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+        HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
 
-    when(authenticationProvider.extractAuthenticatedUser(any(), any())).thenReturn(
-        new AuthenticationResult(null, false));
+        when(httpServletRequest.getRequestURI()).thenReturn("/api/cockpit/plugin/test/static/test");
+        when(httpServletRequest.getMethod()).thenReturn("GET");
 
-    FilterChain filterChain = mock(FilterChain.class);
+        when(authenticationProvider.extractAuthenticatedUser(any(), any()))
+                .thenReturn(new AuthenticationResult("user", true));
 
-    statelessAuthenticationFilter.doFilter(httpServletRequest, httpServletResponse, filterChain);
-    verifyNoInteractions(filterChain);
+        statelessAuthenticationFilter.doFilter(httpServletRequest, httpServletResponse,
+                (servletRequest, servletResponse) -> {
+                    Authentication currentAuthentication = processEngine.getIdentityService().getCurrentAuthentication();
+                    assertNull(currentAuthentication);
+                });
 
-    verify(httpServletResponse).setStatus(eq(401));
-    Authentication currentAuthentication = processEngine.getIdentityService().getCurrentAuthentication();
-    assertNull(currentAuthentication);
-  }
+        Authentication currentAuthentication = processEngine.getIdentityService().getCurrentAuthentication();
+        assertNull(currentAuthentication);
+    }
+
+    @Test
+    void testDoFilterForProtectedResourceWithoutUser() throws ServletException, IOException {
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+        HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+
+        when(httpServletRequest.getRequestURI()).thenReturn("/api/test");
+        when(httpServletRequest.getMethod()).thenReturn("GET");
+
+        when(authenticationProvider.extractAuthenticatedUser(any(), any()))
+                .thenReturn(new AuthenticationResult(null, false));
+
+        FilterChain filterChain = mock(FilterChain.class);
+
+        statelessAuthenticationFilter.doFilter(httpServletRequest, httpServletResponse, filterChain);
+        verifyNoInteractions(filterChain);
+
+        verify(httpServletResponse).setStatus(401);
+        Authentication currentAuthentication = processEngine.getIdentityService().getCurrentAuthentication();
+        assertNull(currentAuthentication);
+    }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <project.build.resourceEncoding>${encoding}</project.build.resourceEncoding>
 
     <!-- versions -->
-    <version.operaton>1.0.0-beta-2</version.operaton>
+    <version.operaton>1.0.0-beta-4-SNAPSHOT</version.operaton>
     <version.springBoot>3.3.5</version.springBoot>
     <version.commons-codec>1.17.1</version.commons-codec>
     <version.testcontainers>1.20.4</version.testcontainers>
@@ -100,6 +100,12 @@
         <version>${version.testcontainers}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-engine</artifactId>
+        <version>${version.operaton}</version>
+        <classifier>junit5</classifier>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
# Operaton Keycloak Identity Provider Pull Request

<!--- Provide a general summary of your changes in the issue title above. Do not @ GitHub users in your pull request title. If 
Update to Operaton 1.0.0-beta-4-SNAPSHOT

## Description
<!--- Describe your pull request in detail here -->
This change updates the Operaton dependency to 1.0.0-beta-4-SNAPSHOT.

It further migrates `StatelessAuthenticationFilterTest` to JUnit 5 and adds the required dependency.

## Additional context
<!--- Why is this change needed? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The keycloak plugin was no longer compatible due to changed dependencies in tests.

## Testing your changes
<!--- Please describe in detail how you tested your changes. -->
<!--- Include any relevant details as to your testing environment, and any tests you ran to determine how/if your change impacts other areas of the extension's codebase, etc. -->
Automatic with the build.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

