### PR TITLE
chore(build): set version to 1.0.0-beta-4-SNAPSHOT

### DIFF
--- a/examples/jwt/pom.xml
+++ b/examples/jwt/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.operaton.bpm.extension.examples</groupId>
     <artifactId>operaton-keycloak-examples</artifactId>
-    <version>1.0.0-beta-3</version>
+    <version>1.0.0-beta-4-SNAPSHOT</version>
   </parent>
 
   <artifactId>operaton-keycloak-examples-jwt</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.operaton.bpm.extension</groupId>
     <artifactId>operaton-keycloak-root</artifactId>
-    <version>1.0.0-beta-3</version>
+    <version>1.0.0-beta-4-SNAPSHOT</version>
   </parent>
 
   <groupId>org.operaton.bpm.extension.examples</groupId>

--- a/examples/sso-kubernetes/pom.xml
+++ b/examples/sso-kubernetes/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.operaton.bpm.extension.examples</groupId>
 		<artifactId>operaton-keycloak-examples</artifactId>
-		<version>1.0.0-beta-3</version>
+		<version>1.0.0-beta-4-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>operaton-keycloak-examples-sso-kubernetes</artifactId>

--- a/extension-all/pom.xml
+++ b/extension-all/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.operaton.bpm.extension</groupId>
     <artifactId>operaton-keycloak-root</artifactId>
-    <version>1.0.0-beta-3</version>
+    <version>1.0.0-beta-4-SNAPSHOT</version>
   </parent>
 
   <artifactId>operaton-keycloak-all</artifactId>

--- a/extension-jwt/pom.xml
+++ b/extension-jwt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.operaton.bpm.extension</groupId>
     <artifactId>operaton-keycloak-root</artifactId>
-    <version>1.0.0-beta-3</version>
+    <version>1.0.0-beta-4-SNAPSHOT</version>
   </parent>
 
   <artifactId>operaton-keycloak-jwt</artifactId>

--- a/extension-run/pom.xml
+++ b/extension-run/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.operaton.bpm.extension</groupId>
     <artifactId>operaton-keycloak-root</artifactId>
-    <version>1.0.0-beta-3</version>
+    <version>1.0.0-beta-4-SNAPSHOT</version>
   </parent>
 
   <artifactId>operaton-keycloak-run</artifactId>

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.operaton.bpm.extension</groupId>
     <artifactId>operaton-keycloak-root</artifactId>
-    <version>1.0.0-beta-3</version>
+    <version>1.0.0-beta-4-SNAPSHOT</version>
   </parent>
 
   <artifactId>operaton-keycloak</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.operaton.bpm.extension</groupId>
   <artifactId>operaton-keycloak-root</artifactId>
-  <version>1.0.0-beta-3</version>
+  <version>1.0.0-beta-4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Operaton - engine plugins - identity - keycloak - root</name>
   <description>A Operaton Identity Provider Plugin for Keycloak</description>


### PR DESCRIPTION
# Prepare next development cycle

- set version to 1.0.0-beta-4-SNAPSHOT

## Context

Current release is 1.0.0-beta-1. The version in `master` is `1.0.0-beta-3` (without -SNAPSHOT !). So in order too avoid any confusion resulting from the usage of beta-2/beta-3, I suggest to target 1.0.0-beta-4 as next version.